### PR TITLE
Add support to get/list/update/delete config repos

### DIFF
--- a/gocd/config_repo.go
+++ b/gocd/config_repo.go
@@ -34,7 +34,7 @@ type ConfigRepoProperty struct {
 	EncryptedValue string `json:"encrypted_value,omitempty"`
 }
 
-// List lists all available config repos, these are config repositories that
+// List returns all available config repos, these are config repositories that
 // are present in the in `cruise-config.xml`
 func (s *ConfigRepoService) List(ctx context.Context) (repos []*ConfigRepo, resp *APIResponse, err error) {
 	r := &ConfigReposListResponse{}

--- a/gocd/config_repo.go
+++ b/gocd/config_repo.go
@@ -2,6 +2,7 @@ package gocd
 
 import (
 	"context"
+	"fmt"
 )
 
 // ConfigRepoService allows admin users to define and manage config repos using
@@ -24,6 +25,7 @@ type ConfigRepo struct {
 	Material      Material              `json:"material"`
 	Configuration []*ConfigRepoProperty `json:"configuration"`
 	Links         *HALLinks             `json:"_links,omitempty,omitempty"`
+	Version       string                `json:"version,omitempty"`
 	client        *Client
 }
 
@@ -49,5 +51,18 @@ func (s *ConfigRepoService) List(ctx context.Context) (repos []*ConfigRepo, resp
 	}
 	repos = r.Embedded.Repos
 
+	return
+}
+
+// Get fetches the config repo object for a specified id
+func (s *ConfigRepoService) Get(ctx context.Context, id string) (repo *ConfigRepo, resp *APIResponse, err error) {
+	repo = &ConfigRepo{}
+	_, resp, err = s.client.getAction(ctx, &APIClientRequest{
+		Path:         fmt.Sprintf("admin/config_repos/%s", id),
+		ResponseBody: repo,
+		APIVersion:   apiV1,
+	})
+
+	repo.client = s.client
 	return
 }

--- a/gocd/config_repo.go
+++ b/gocd/config_repo.go
@@ -55,21 +55,20 @@ func (s *ConfigRepoService) List(ctx context.Context) (repos []*ConfigRepo, resp
 }
 
 // Get fetches the config repo object for a specified id
-func (s *ConfigRepoService) Get(ctx context.Context, id string) (repo *ConfigRepo, resp *APIResponse, err error) {
-	repo = &ConfigRepo{}
+func (s *ConfigRepoService) Get(ctx context.Context, id string) (out *ConfigRepo, resp *APIResponse, err error) {
+	out = &ConfigRepo{}
 	_, resp, err = s.client.getAction(ctx, &APIClientRequest{
 		Path:         fmt.Sprintf("admin/config_repos/%s", id),
-		ResponseBody: repo,
+		ResponseBody: out,
 		APIVersion:   apiV1,
 	})
 
-	repo.client = s.client
+	out.client = s.client
 	return
 }
 
 // Create a config repo
 func (s *ConfigRepoService) Create(ctx context.Context, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
-
 	out = &ConfigRepo{}
 	_, resp, err = s.client.postAction(ctx, &APIClientRequest{
 		Path:         "admin/config_repos",
@@ -78,5 +77,20 @@ func (s *ConfigRepoService) Create(ctx context.Context, cr *ConfigRepo) (out *Co
 		APIVersion:   apiV1,
 	})
 
+	out.client = s.client
+	return
+}
+
+// Update config repos for specified config repo id
+func (s *ConfigRepoService) Update(ctx context.Context, id string, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
+	out = &ConfigRepo{}
+	_, resp, err = s.client.putAction(ctx, &APIClientRequest{
+		Path:         fmt.Sprintf("admin/config_repos/%s", id),
+		RequestBody:  cr,
+		ResponseBody: out,
+		APIVersion:   apiV1,
+	})
+
+	out.client = s.client
 	return
 }

--- a/gocd/config_repo.go
+++ b/gocd/config_repo.go
@@ -94,3 +94,8 @@ func (s *ConfigRepoService) Update(ctx context.Context, id string, cr *ConfigRep
 	out.client = s.client
 	return
 }
+
+// Delete the specified config repo
+func (s *ConfigRepoService) Delete(ctx context.Context, id string) (string, *APIResponse, error) {
+	return s.client.deleteAction(ctx, fmt.Sprintf("admin/config_repos/%s", id), apiV1)
+}

--- a/gocd/config_repo.go
+++ b/gocd/config_repo.go
@@ -38,16 +38,16 @@ type ConfigRepoProperty struct {
 
 // List returns all available config repos, these are config repositories that
 // are present in the in `cruise-config.xml`
-func (s *ConfigRepoService) List(ctx context.Context) (repos []*ConfigRepo, resp *APIResponse, err error) {
+func (crs *ConfigRepoService) List(ctx context.Context) (repos []*ConfigRepo, resp *APIResponse, err error) {
 	r := &ConfigReposListResponse{}
-	_, resp, err = s.client.getAction(ctx, &APIClientRequest{
+	_, resp, err = crs.client.getAction(ctx, &APIClientRequest{
 		Path:         "admin/config_repos",
 		ResponseBody: r,
 		APIVersion:   apiV1,
 	})
 
 	for _, repos := range r.Embedded.Repos {
-		repos.client = s.client
+		repos.client = crs.client
 	}
 	repos = r.Embedded.Repos
 
@@ -55,47 +55,47 @@ func (s *ConfigRepoService) List(ctx context.Context) (repos []*ConfigRepo, resp
 }
 
 // Get fetches the config repo object for a specified id
-func (s *ConfigRepoService) Get(ctx context.Context, id string) (out *ConfigRepo, resp *APIResponse, err error) {
+func (crs *ConfigRepoService) Get(ctx context.Context, id string) (out *ConfigRepo, resp *APIResponse, err error) {
 	out = &ConfigRepo{}
-	_, resp, err = s.client.getAction(ctx, &APIClientRequest{
+	_, resp, err = crs.client.getAction(ctx, &APIClientRequest{
 		Path:         fmt.Sprintf("admin/config_repos/%s", id),
 		ResponseBody: out,
 		APIVersion:   apiV1,
 	})
 
-	out.client = s.client
+	out.client = crs.client
 	return
 }
 
 // Create a config repo
-func (s *ConfigRepoService) Create(ctx context.Context, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
+func (crs *ConfigRepoService) Create(ctx context.Context, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
 	out = &ConfigRepo{}
-	_, resp, err = s.client.postAction(ctx, &APIClientRequest{
+	_, resp, err = crs.client.postAction(ctx, &APIClientRequest{
 		Path:         "admin/config_repos",
 		RequestBody:  cr,
 		ResponseBody: out,
 		APIVersion:   apiV1,
 	})
 
-	out.client = s.client
+	out.client = crs.client
 	return
 }
 
 // Update config repos for specified config repo id
-func (s *ConfigRepoService) Update(ctx context.Context, id string, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
+func (crs *ConfigRepoService) Update(ctx context.Context, id string, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
 	out = &ConfigRepo{}
-	_, resp, err = s.client.putAction(ctx, &APIClientRequest{
+	_, resp, err = crs.client.putAction(ctx, &APIClientRequest{
 		Path:         fmt.Sprintf("admin/config_repos/%s", id),
 		RequestBody:  cr,
 		ResponseBody: out,
 		APIVersion:   apiV1,
 	})
 
-	out.client = s.client
+	out.client = crs.client
 	return
 }
 
 // Delete the specified config repo
-func (s *ConfigRepoService) Delete(ctx context.Context, id string) (string, *APIResponse, error) {
-	return s.client.deleteAction(ctx, fmt.Sprintf("admin/config_repos/%s", id), apiV1)
+func (crs *ConfigRepoService) Delete(ctx context.Context, id string) (string, *APIResponse, error) {
+	return crs.client.deleteAction(ctx, fmt.Sprintf("admin/config_repos/%s", id), apiV1)
 }

--- a/gocd/config_repo.go
+++ b/gocd/config_repo.go
@@ -23,7 +23,7 @@ type ConfigRepo struct {
 	ID            string                `json:"id"`
 	PluginID      string                `json:"plugin_id"`
 	Material      Material              `json:"material"`
-	Configuration []*ConfigRepoProperty `json:"configuration"`
+	Configuration []*ConfigRepoProperty `json:"configuration,omitempty"`
 	Links         *HALLinks             `json:"_links,omitempty,omitempty"`
 	Version       string                `json:"version,omitempty"`
 	client        *Client
@@ -64,5 +64,19 @@ func (s *ConfigRepoService) Get(ctx context.Context, id string) (repo *ConfigRep
 	})
 
 	repo.client = s.client
+	return
+}
+
+// Create a config repo
+func (s *ConfigRepoService) Create(ctx context.Context, cr *ConfigRepo) (out *ConfigRepo, resp *APIResponse, err error) {
+
+	out = &ConfigRepo{}
+	_, resp, err = s.client.postAction(ctx, &APIClientRequest{
+		Path:         "admin/config_repos",
+		RequestBody:  cr,
+		ResponseBody: out,
+		APIVersion:   apiV1,
+	})
+
 	return
 }

--- a/gocd/config_repo_test.go
+++ b/gocd/config_repo_test.go
@@ -13,7 +13,26 @@ func TestConfigRepo(t *testing.T) {
 	setup()
 	defer teardown()
 
+	t.Run("Get", testConfigRepoGet)
 	t.Run("List", testConfigRepoList)
+}
+
+func testConfigRepoGet(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/admin/config_repos/repo1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+		j, _ := ioutil.ReadFile("test/resources/configrepos.0.json")
+		w.Header().Set("Etag", "mock-etag")
+		fmt.Fprint(w, string(j))
+	})
+
+	repo, _, err := client.ConfigRepos.Get(context.Background(), "repo1")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "mock-etag", repo.Version)
+	testConfigRepo(t, repo)
 }
 
 func testConfigRepoList(t *testing.T) {

--- a/gocd/config_repo_test.go
+++ b/gocd/config_repo_test.go
@@ -1,0 +1,51 @@
+package gocd
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestConfigRepo(t *testing.T) {
+	setup()
+	defer teardown()
+
+	t.Run("List", testConfigRepoList)
+}
+
+func testConfigRepoList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/admin/config_repos", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+		j, _ := ioutil.ReadFile("test/resources/configrepos.1.json")
+		fmt.Fprint(w, string(j))
+	})
+
+	repos, _, err := client.ConfigRepos.List(context.Background())
+
+	assert.Nil(t, err)
+	assert.Len(t, repos, 1)
+
+	testConfigRepo(t, repos[0])
+}
+
+func testConfigRepo(t *testing.T, repo *ConfigRepo) {
+
+	for _, attribute := range []EqualityTest{
+		{repo.Links.Get("Self").URL.String(), "https://ci.example.com/go/api/admin/config_repos/repo1"},
+		{repo.Links.Get("Doc").URL.String(), "https://api.gocd.org/#config-repos"},
+		{repo.Links.Get("Find").URL.String(), "https://ci.example.com/go/api/admin/config_repos/:id"},
+		{repo.ID, "repo1"},
+		{repo.PluginID, "json.config.plugin"},
+		{repo.Material.Type, "git"},
+		{repo.Material.Attributes.(*MaterialAttributesGit).URL, "https://github.com/config-repo/gocd-json-config-example.git"},
+		{repo.Material.Attributes.(*MaterialAttributesGit).Branch, "master"},
+	} {
+		assert.Equal(t, attribute.wanted, attribute.got)
+	}
+}

--- a/gocd/config_repo_test.go
+++ b/gocd/config_repo_test.go
@@ -15,6 +15,7 @@ func TestConfigRepo(t *testing.T) {
 
 	t.Run("Get", testConfigRepoGet)
 	t.Run("List", testConfigRepoList)
+	t.Run("Create", testConfigRepoCreate)
 }
 
 func testConfigRepoGet(t *testing.T) {
@@ -51,6 +52,25 @@ func testConfigRepoList(t *testing.T) {
 	assert.Len(t, repos, 1)
 
 	testConfigRepo(t, repos[0])
+}
+
+func testConfigRepoCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/admin/config_repos", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
+		j, _ := ioutil.ReadFile("test/resources/configrepos.0.json")
+		fmt.Fprint(w, string(j))
+	})
+
+	r := ConfigRepo{ID: "repo1", PluginID: "json.config.plugin", Material: Material{Type: "git", Attributes: &MaterialAttributesGit{URL: "https://github.com/config-repo/gocd-json-config-example.git", Branch: "master", AutoUpdate: true}}}
+	repo, _, err := client.ConfigRepos.Create(context.Background(), &r)
+	if err != nil {
+		t.Error(t, err)
+	}
+
+	assert.NotNil(t, repo)
 }
 
 func testConfigRepo(t *testing.T, repo *ConfigRepo) {

--- a/gocd/example_test.go
+++ b/gocd/example_test.go
@@ -43,6 +43,7 @@ func ExampleConfigRepoService_List() {
 	if err != nil {
 		panic(err)
 	}
+	// Loops through the list of repositories to display some basic informations
 	for _, r := range l {
 		fmt.Printf("Pipeline: %s\n\tMaterial type: %s\n", r.ID, r.Material.Type)
 		if r.Material.Type == "git" {
@@ -50,4 +51,24 @@ func ExampleConfigRepoService_List() {
 		}
 		fmt.Printf("\tNumber of configuration parameters: %d\n\n", len(r.Configuration))
 	}
+}
+
+func ExampleConfigRepoService_Get() {
+	cfg := gocd.Configuration{
+		Server:   "https://my_gocd/go/", // don't forget the "/go/" at the end of the url to avoid issues!
+		Username: "ApiUser",
+		Password: "MySecretPassword",
+	}
+
+	c := cfg.Client()
+
+	r, _, err := c.ConfigRepos.Get(context.Background(), "my_repo_config_id")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Pipeline: %s\n\tMaterial type: %s\n", r.ID, r.Material.Type)
+	if r.Material.Type == "git" {
+		fmt.Printf("\tMaterial url: %s\n", r.Material.Attributes.(*gocd.MaterialAttributesGit).URL)
+	}
+	fmt.Printf("\tNumber of configuration parameters: %d\n\n", len(r.Configuration))
 }

--- a/gocd/example_test.go
+++ b/gocd/example_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/beamly/go-gocd/gocd"
 )
 
-func ExampleAgent_List() {
+func ExampleAgentsService_List() {
 	cfg := gocd.Configuration{
 		Server:   "https://my_gocd/go/", // don't forget the "/go/" at the end of the url to avoid issues!
 		Username: "ApiUser",
@@ -28,4 +28,26 @@ func ExampleAgent_List() {
 	}
 
 	fmt.Println(a)
+}
+
+func ExampleConfigRepoService_List() {
+	cfg := gocd.Configuration{
+		Server:   "https://my_gocd/go/", // don't forget the "/go/" at the end of the url to avoid issues!
+		Username: "ApiUser",
+		Password: "MySecretPassword",
+	}
+
+	c := cfg.Client()
+
+	l, _, err := c.ConfigRepos.List(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	for _, r := range l {
+		fmt.Printf("Pipeline: %s\n\tMaterial type: %s\n", r.ID, r.Material.Type)
+		if r.Material.Type == "git" {
+			fmt.Printf("\tMaterial url: %s\n", r.Material.Attributes.(*gocd.MaterialAttributesGit).URL)
+		}
+		fmt.Printf("\tNumber of configuration parameters: %d\n\n", len(r.Configuration))
+	}
 }

--- a/gocd/example_test.go
+++ b/gocd/example_test.go
@@ -1,0 +1,31 @@
+package gocd_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/beamly/go-gocd/gocd"
+)
+
+func ExampleAgent_List() {
+	cfg := gocd.Configuration{
+		Server:   "https://my_gocd/go/", // don't forget the "/go/" at the end of the url to avoid issues!
+		Username: "ApiUser",
+		Password: "MySecretPassword",
+	}
+
+	c := cfg.Client()
+
+	// list all agents in use by the GoCD Server
+	var a []*gocd.Agent
+	var err error
+	var r *gocd.APIResponse
+	if a, r, err = c.Agents.List(context.Background()); err != nil {
+		if r.HTTP.StatusCode == 404 {
+			fmt.Println("Couldn't find agent")
+		} else {
+			panic(err)
+		}
+	}
+
+	fmt.Println(a)
+}

--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -86,6 +86,7 @@ type Client struct {
 	Pipelines         *PipelinesService
 	PipelineConfigs   *PipelineConfigsService
 	Configuration     *ConfigurationService
+	ConfigRepos       *ConfigRepoService
 	Encryption        *EncryptionService
 	Plugins           *PluginsService
 	Environments      *EnvironmentsService
@@ -160,6 +161,7 @@ func NewClient(cfg *Configuration, httpClient *http.Client) *Client {
 	c.Pipelines = (*PipelinesService)(&c.common)
 	c.PipelineConfigs = (*PipelineConfigsService)(&c.common)
 	c.Configuration = (*ConfigurationService)(&c.common)
+	c.ConfigRepos = (*ConfigRepoService)(&c.common)
 	c.Encryption = (*EncryptionService)(&c.common)
 	c.Plugins = (*PluginsService)(&c.common)
 	c.Environments = (*EnvironmentsService)(&c.common)

--- a/gocd/resource_config_repo.go
+++ b/gocd/resource_config_repo.go
@@ -1,11 +1,11 @@
 package gocd
 
 // SetVersion sets a version string for this config repo
-func (p *ConfigRepo) SetVersion(version string) {
-	p.Version = version
+func (c *ConfigRepo) SetVersion(version string) {
+	c.Version = version
 }
 
 // GetVersion retrieves a version string for this config repo
-func (p *ConfigRepo) GetVersion() (version string) {
-	return p.Version
+func (c *ConfigRepo) GetVersion() (version string) {
+	return c.Version
 }

--- a/gocd/resource_config_repo.go
+++ b/gocd/resource_config_repo.go
@@ -1,0 +1,11 @@
+package gocd
+
+// SetVersion sets a version string for this config repo
+func (p *ConfigRepo) SetVersion(version string) {
+	p.Version = version
+}
+
+// GetVersion retrieves a version string for this config repo
+func (p *ConfigRepo) GetVersion() (version string) {
+	return p.Version
+}

--- a/gocd/resource_config_repo_test.go
+++ b/gocd/resource_config_repo_test.go
@@ -1,0 +1,19 @@
+package gocd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfigRepoGetVersion(t *testing.T) {
+	repo := ConfigRepo{Version: "test-version"}
+	version := repo.GetVersion()
+	assert.Equal(t, repo.Version, version)
+}
+
+func TestConfigRepoSetVersion(t *testing.T) {
+	repo := ConfigRepo{}
+	assert.Equal(t, repo.Version, "")
+	repo.SetVersion("test-version")
+	assert.Equal(t, repo.Version, "test-version")
+}

--- a/gocd/test/resources/configrepos.0.json
+++ b/gocd/test/resources/configrepos.0.json
@@ -1,0 +1,27 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://ci.example.com/go/api/admin/config_repos/repo1"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/#config-repos"
+    },
+    "find": {
+      "href": "https://ci.example.com/go/api/admin/config_repos/:id"
+    }
+  },
+  "id": "repo1",
+  "plugin_id": "json.config.plugin",
+  "material": {
+    "type": "git",
+    "attributes": {
+      "url": "https://github.com/config-repo/gocd-json-config-example.git",
+      "name": null,
+      "branch": "master",
+      "auto_update": true
+    }
+  },
+  "configuration": [
+
+  ]
+}

--- a/gocd/test/resources/configrepos.1.json
+++ b/gocd/test/resources/configrepos.1.json
@@ -1,0 +1,37 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://ci.example.com/go/api/admin/config_repos"
+    }
+  },
+  "_embedded": {
+    "config_repos": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://ci.example.com/go/api/admin/config_repos/repo1"
+          },
+          "doc": {
+            "href": "https://api.gocd.org/#config-repos"
+          },
+          "find": {
+            "href": "https://ci.example.com/go/api/admin/config_repos/:id"
+          }
+        },
+        "id": "repo1",
+        "plugin_id": "json.config.plugin",
+        "material": {
+          "type": "git",
+          "attributes": {
+            "url": "https://github.com/config-repo/gocd-json-config-example.git",
+            "name": null,
+            "branch": "master",
+            "auto_update": true
+          }
+        },
+        "configuration": [
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Hi,

This PR adds the support for:
* `the config repo object`: https://api.gocd.org/current/#the-config-repo-object
* `getting all Config repos`: https://api.gocd.org/current/#get-all-config-repos
* `getting a config repo from an ID`: https://api.gocd.org/current/#get-a-config-repo
* `creating a config repo`: https://api.gocd.org/current/#create-a-config-repo
* `updating a config repo`: https://api.gocd.org/current/#update-config-repo
* `deleting a config repo`: https://api.gocd.org/current/#delete-a-config-repo

It also adds examples in `example_test.go` following the example of what is done in the standard packages like [time](https://golang.org/src/time/example_test.go)

I used `agent.go` and `agent_test.go` as examples to write the code and tested it also against my gocd server for real-life testing, works fine.

Let me know if I should change something before merging.

Thanks
Joseph