### PR TITLE
Add Server Version Endpoint

### DIFF
--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -92,6 +92,7 @@ type Client struct {
 	Environments      *EnvironmentsService
 	Properties        *PropertiesService
 	Roles             *RoleService
+	ServerVersion     *ServerVersionService
 
 	common service
 	cookie string
@@ -168,6 +169,7 @@ func NewClient(cfg *Configuration, httpClient *http.Client) *Client {
 	c.Environments = (*EnvironmentsService)(&c.common)
 	c.Properties = (*PropertiesService)(&c.common)
 	c.Roles = (*RoleService)(&c.common)
+	c.ServerVersion = (*ServerVersionService)(&c.common)
 
 	SetupLogging(c.Log)
 

--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -2,16 +2,25 @@ package gocd
 
 import (
 	"context"
+	"strings"
+	"strconv"
 )
 
 type ServerVersionService service
 
+type ServerVersionParts struct {
+	Major int
+	Minor int
+	Patch int
+}
+
 type ServerVersion struct {
-	Version     string `json:"version"`
-	BuildNumber string `json:"build_number"`
-	GitSha      string `json:"git_sha"`
-	FullVersion string `json:"full_version"`
-	CommitURL   string `json:"commit_url"`
+	Version      string `json:"version"`
+	VersionParts *ServerVersionParts
+	BuildNumber  string `json:"build_number"`
+	GitSha       string `json:"git_sha"`
+	FullVersion  string `json:"full_version"`
+	CommitURL    string `json:"commit_url"`
 }
 
 // Get retrieves information about a specific plugin.
@@ -22,6 +31,29 @@ func (svs *ServerVersionService) Get(ctx context.Context) (v *ServerVersion, res
 		ResponseBody: v,
 		APIVersion:   apiV1,
 	})
+
+	if err == nil {
+		var major, minor, patch int
+		versionParts := strings.Split(v.Version, ".")
+
+		if major, err = strconv.Atoi(versionParts[0]); err != nil {
+			return
+		}
+
+		if minor, err = strconv.Atoi(versionParts[1]); err != nil {
+			return
+		}
+
+		if patch, err = strconv.Atoi(versionParts[2]); err != nil {
+			return
+		}
+
+		v.VersionParts = &ServerVersionParts{
+			Major: major,
+			Minor: minor,
+			Patch: patch,
+		}
+	}
 
 	return
 }

--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -2,8 +2,8 @@ package gocd
 
 import (
 	"context"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 type ServerVersionService service

--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -1,0 +1,27 @@
+package gocd
+
+import (
+	"context"
+)
+
+type ServerVersionService service
+
+type ServerVersion struct {
+	Version     string `json:"version"`
+	BuildNumber string `json:"build_number"`
+	GitSha      string `json:"git_sha"`
+	FullVersion string `json:"full_version"`
+	CommitURL   string `json:"commit_url"`
+}
+
+// Get retrieves information about a specific plugin.
+func (svs *ServerVersionService) Get(ctx context.Context) (v *ServerVersion, resp *APIResponse, err error) {
+	v = &ServerVersion{}
+	_, resp, err = svs.client.getAction(ctx, &APIClientRequest{
+		Path:         "version",
+		ResponseBody: v,
+		APIVersion:   apiV1,
+	})
+
+	return
+}

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -36,6 +36,11 @@ func testServerVersion(t *testing.T) {
 		GitSha:      "a7a5717cbd60c30006314fb8dd529796c93adaf0",
 		FullVersion: "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
 		CommitURL:   "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
+		VersionParts: &ServerVersionParts{
+			Major: 16,
+			Minor: 6,
+			Patch: 0,
+		},
 	}, v)
 
 }

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -1,0 +1,41 @@
+package gocd
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestServerVersion(t *testing.T) {
+	setup()
+	defer teardown()
+
+	t.Run("ServerVersion", testServerVersion)
+}
+
+func testServerVersion(t *testing.T) {
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+		assert.Equal(t, apiV1, r.Header.Get("Accept"))
+
+		j, _ := ioutil.ReadFile("test/resources/server-version.v1.1.json")
+
+		fmt.Fprint(w, string(j))
+	})
+
+	v, _, err := client.ServerVersion.Get(context.Background())
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, &ServerVersion{
+		Version:     "16.6.0",
+		BuildNumber: "3348",
+		GitSha:      "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+		FullVersion: "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+		CommitURL:   "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
+	}, v)
+
+}

--- a/gocd/test/resources/server-version.v1.1.json
+++ b/gocd/test/resources/server-version.v1.1.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://build.go.cd/go/api/version"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/#version"
+    }
+  },
+  "version": "16.6.0",
+  "build_number": "3348",
+  "git_sha": "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+  "full_version": "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+  "commit_url": "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0"
+}

--- a/gocd/test/resources/server-version.v1.2.json
+++ b/gocd/test/resources/server-version.v1.2.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://build.go.cd/go/api/version"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/#version"
+    }
+  },
+  "version": "a.6.0",
+  "build_number": "3348",
+  "git_sha": "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+  "full_version": "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+  "commit_url": "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0"
+}

--- a/gocd/test/resources/server-version.v1.3.json
+++ b/gocd/test/resources/server-version.v1.3.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://build.go.cd/go/api/version"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/#version"
+    }
+  },
+  "version": "16.b.0",
+  "build_number": "3348",
+  "git_sha": "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+  "full_version": "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+  "commit_url": "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0"
+}

--- a/gocd/test/resources/server-version.v1.4.json
+++ b/gocd/test/resources/server-version.v1.4.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://build.go.cd/go/api/version"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/#version"
+    }
+  },
+  "version": "16.6.c",
+  "build_number": "3348",
+  "git_sha": "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+  "full_version": "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+  "commit_url": "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0"
+}


### PR DESCRIPTION
Implemented the server version endpoint as described here: https://api.gocd.org/current/#version