### PR TITLE
change from Stage to StageInstance in PipelineInstance

### DIFF
--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -65,12 +65,12 @@ type PipelineHistory struct {
 
 // PipelineInstance describes a single pipeline run
 type PipelineInstance struct {
-	BuildCause   BuildCause `json:"build_cause"`
-	CanRun       bool       `json:"can_run"`
-	Name         string     `json:"name"`
-	NaturalOrder int        `json:"natural_order"`
-	Comment      string     `json:"comment"`
-	Stages       []*Stage   `json:"stages"`
+	BuildCause   BuildCause       `json:"build_cause"`
+	CanRun       bool             `json:"can_run"`
+	Name         string           `json:"name"`
+	NaturalOrder int              `json:"natural_order"`
+	Comment      string           `json:"comment"`
+	Stages       []*StageInstance `json:"stages"`
 }
 
 // BuildCause describes the triggers which caused the build to start.

--- a/gocd/pipeline_test.go
+++ b/gocd/pipeline_test.go
@@ -3,10 +3,11 @@ package gocd
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPipelineService(t *testing.T) {
@@ -168,12 +169,6 @@ func testPipelineServiceGet(t *testing.T) {
 
 	s := p.Stages[0]
 	assert.Equal(t, "stage1", s.Name)
-	assert.Equal(t, false, s.FetchMaterials)
-	assert.Equal(t, false, s.CleanWorkingDirectory)
-	assert.Equal(t, false, s.NeverCleanupArtifacts)
-
-	assert.Len(t, s.EnvironmentVariables, 0)
-	assert.Nil(t, s.Approval)
 }
 
 func testPipelineServiceGetHistory(t *testing.T) {

--- a/gocd/resource_stage_instance.go
+++ b/gocd/resource_stage_instance.go
@@ -18,7 +18,7 @@ func (s *StageInstance) JSONString() (string, error) {
 // Validate ensures the attributes attached to this structure are ready for submission to the GoCD API.
 func (s *StageInstance) Validate() error {
 	if s.Name == "" {
-		return errors.New("`gocd.Stage.Name` is empty")
+		return errors.New("`gocd.StageInstance.Name` is empty")
 	}
 
 	if len(s.Jobs) == 0 {

--- a/gocd/resource_stage_instance.go
+++ b/gocd/resource_stage_instance.go
@@ -1,0 +1,35 @@
+package gocd
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// JSONString returns a string of this stage as a JSON object.
+func (s *StageInstance) JSONString() (string, error) {
+	err := s.Validate()
+	if err != nil {
+		return "", err
+	}
+	bdy, err := json.MarshalIndent(s, "", "  ")
+	return string(bdy), err
+}
+
+// Validate ensures the attributes attached to this structure are ready for submission to the GoCD API.
+func (s *StageInstance) Validate() error {
+	if s.Name == "" {
+		return errors.New("`gocd.Stage.Name` is empty")
+	}
+
+	if len(s.Jobs) == 0 {
+		return errors.New("At least one `Job` must be specified")
+	}
+
+	for _, job := range s.Jobs {
+		if err := job.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/gocd/stage_instance.go
+++ b/gocd/stage_instance.go
@@ -1,0 +1,54 @@
+package gocd
+
+/*
+{
+			"name": "stage1",
+			"approved_by": "admin",
+			"jobs": [
+			  {
+				"name": "job1",
+				"result": "Failed",
+				"state": "Completed",
+				"id": 13,
+				"scheduled_date": 1436172201081
+			  }
+			],
+			"can_run": true,
+			"result": "Failed",
+			"approval_type": "success",
+			"counter": "1",
+			"id": 13,
+			"operate_permission": true,
+			"rerun_of_counter": null,
+			"scheduled": true
+		  }
+
+  private String name;
+    private long id;
+    private JobHistory jobHistory;
+    private boolean canRun;
+    private boolean scheduled = true; // true if this stage history really happened
+    private String approvalType;
+    private String approvedBy;
+    private String counter;
+    private boolean operatePermission;
+    private StageInstanceModel previousStage;
+    private StageResult result;
+    private StageIdentifier identifier;
+	private Integer rerunOfCounter;
+*/
+
+// StageInstance represents the stage from the result from a pipeline run
+type StageInstance struct {
+	Name              string `json:"name"`
+	ID                int    `json:"id"`
+	Jobs              []*Job `json:"jobs,omitempty"`
+	CanRun            bool   `json:"can_run"`
+	Scheduled         bool   `json:"scheduled"`
+	ApprovalType      string `json:"approval_type,omitempty"`
+	ApprovedBy        string `json:"approved_by,omitempty"`
+	Counter           string `json:"counter,omitempty"`
+	OperatePermission bool   `json:"operate_permission,omitempty"`
+	Result            string `json:"result,omitempty"`
+	RerunOfCounter    string `json:"rerun_of_counter,omitempty"`
+}

--- a/gocd/stage_instance.go
+++ b/gocd/stage_instance.go
@@ -1,43 +1,5 @@
 package gocd
 
-/*
-{
-			"name": "stage1",
-			"approved_by": "admin",
-			"jobs": [
-			  {
-				"name": "job1",
-				"result": "Failed",
-				"state": "Completed",
-				"id": 13,
-				"scheduled_date": 1436172201081
-			  }
-			],
-			"can_run": true,
-			"result": "Failed",
-			"approval_type": "success",
-			"counter": "1",
-			"id": 13,
-			"operate_permission": true,
-			"rerun_of_counter": null,
-			"scheduled": true
-		  }
-
-  private String name;
-    private long id;
-    private JobHistory jobHistory;
-    private boolean canRun;
-    private boolean scheduled = true; // true if this stage history really happened
-    private String approvalType;
-    private String approvedBy;
-    private String counter;
-    private boolean operatePermission;
-    private StageInstanceModel previousStage;
-    private StageResult result;
-    private StageIdentifier identifier;
-	private Integer rerunOfCounter;
-*/
-
 // StageInstance represents the stage from the result from a pipeline run
 type StageInstance struct {
 	Name              string `json:"name"`

--- a/gocd/stage_instance_test.go
+++ b/gocd/stage_instance_test.go
@@ -18,7 +18,7 @@ func testStageInstanceJSONStringFail(t *testing.T) {
 		ID:         13,
 	}
 	_, err := s.JSONString()
-	assert.EqualError(t, err, "`gocd.Stage.Name` is empty")
+	assert.EqualError(t, err, "`gocd.StageInstance.Name` is empty")
 }
 
 func testStageInstanceJSONString(t *testing.T) {
@@ -69,22 +69,11 @@ func testStageInstanceJSONString(t *testing.T) {
 }`, j)
 }
 
-/*
-expected: "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approved_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
-  actual: "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approval_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
-
-*/
-// "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"approval_type\": \"success\",\n  \"approved_by\": \"admin\",\n  \"counter\": \"1\",\n  \"operate_permission\": true,\n  \"scheduled\": true\n  \"result\": \"Failed\",\n}"
-// "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approval_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
-
-// {\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"approval_type\": \"success\",\n  \"approved_by\": \"admin\",\n  \"counter\": \"1\",\n  \"operate_permission\": true,\n  \"scheduled\": true,\n  \"result\": \"Failed\"\n}
-// {\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approval_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
-
 func testStageInstanceValidate(t *testing.T) {
-	s := Stage{}
+	s := StageInstance{}
 
 	err := s.Validate()
-	assert.EqualError(t, err, "`gocd.Stage.Name` is empty")
+	assert.EqualError(t, err, "`gocd.StageInstance.Name` is empty")
 
 	s.Name = "test-stage"
 	err = s.Validate()

--- a/gocd/stage_instance_test.go
+++ b/gocd/stage_instance_test.go
@@ -1,0 +1,100 @@
+package gocd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStageInstance(t *testing.T) {
+	t.Run("Validate", testStageInstanceValidate)
+	t.Run("JSONStringFail", testStageInstanceJSONStringFail)
+	t.Run("JSONString", testStageInstanceJSONString)
+}
+
+func testStageInstanceJSONStringFail(t *testing.T) {
+	s := StageInstance{
+		ApprovedBy: "admin",
+		ID:         13,
+	}
+	_, err := s.JSONString()
+	assert.EqualError(t, err, "`gocd.Stage.Name` is empty")
+}
+
+func testStageInstanceJSONString(t *testing.T) {
+	s := StageInstance{
+		Name:       "stage1",
+		ApprovedBy: "admin",
+		Jobs: []*Job{
+			{
+				Name:          "job1",
+				Result:        "Failed",
+				State:         "Completed",
+				ID:            13,
+				ScheduledDate: 1436172201081,
+			},
+		},
+		CanRun:            true,
+		Result:            "Failed",
+		ApprovalType:      "success",
+		Counter:           "1",
+		ID:                13,
+		OperatePermission: true,
+		Scheduled:         true,
+	}
+	j, err := s.JSONString()
+	if err != nil {
+		assert.Nil(t, err)
+	}
+	assert.Equal(
+		t, `{
+  "name": "stage1",
+  "id": 13,
+  "jobs": [
+    {
+      "name": "job1",
+      "scheduled_date": 1436172201081,
+      "result": "Failed",
+      "state": "Completed",
+      "id": 13
+    }
+  ],
+  "can_run": true,
+  "scheduled": true,
+  "approval_type": "success",
+  "approved_by": "admin",
+  "counter": "1",
+  "operate_permission": true,
+  "result": "Failed"
+}`, j)
+}
+
+/*
+expected: "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approved_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
+  actual: "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approval_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
+
+*/
+// "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"approval_type\": \"success\",\n  \"approved_by\": \"admin\",\n  \"counter\": \"1\",\n  \"operate_permission\": true,\n  \"scheduled\": true\n  \"result\": \"Failed\",\n}"
+// "{\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approval_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
+
+// {\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"approval_type\": \"success\",\n  \"approved_by\": \"admin\",\n  \"counter\": \"1\",\n  \"operate_permission\": true,\n  \"scheduled\": true,\n  \"result\": \"Failed\"\n}
+// {\n  \"name\": \"stage1\",\n  \"id\": 13,\n  \"jobs\": [\n    {\n      \"name\": \"job1\",\n      \"scheduled_date\": 1436172201081,\n      \"result\": \"Failed\",\n      \"state\": \"Completed\",\n      \"id\": 13\n    }\n  ],\n  \"can_run\": true,\n  \"scheduled\": true,\n  \"approval_type\": \"success\",\n  \"approval_by\": \"admin\",\n  \"counter\": 1,\n  \"operate_permission\": true,\n  \"result\": \"Failed\"\n}"
+
+func testStageInstanceValidate(t *testing.T) {
+	s := Stage{}
+
+	err := s.Validate()
+	assert.EqualError(t, err, "`gocd.Stage.Name` is empty")
+
+	s.Name = "test-stage"
+	err = s.Validate()
+	assert.EqualError(t, err, "At least one `Job` must be specified")
+
+	s.Jobs = []*Job{{}}
+	err = s.Validate()
+	assert.EqualError(t, err, "`gocd.Jobs.Name` is empty")
+
+	s.Jobs[0].Name = "test-job"
+	err = s.Validate()
+	assert.Nil(t, err)
+}

--- a/gocd/stages_test.go
+++ b/gocd/stages_test.go
@@ -1,8 +1,9 @@
 package gocd
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStages(t *testing.T) {


### PR DESCRIPTION
Implements a new struct `StageInstance` to replace the `Stage` struct in a `PipelineInstance`.
The stage instance contains the result for a pipeline instance. `Stage` was used before, but it contains the configuration for a pipeline. See details in issue #127 .