### PR TITLE
Feature/update role

### DIFF
--- a/gocd/resource_role.go
+++ b/gocd/resource_role.go
@@ -1,0 +1,11 @@
+package gocd
+
+// SetVersion sets a version string for this role
+func (r *Role) SetVersion(version string) {
+	r.Version = version
+}
+
+// GetVersion retrieves a version string for this role
+func (r Role) GetVersion() (version string) {
+	return r.Version
+}

--- a/gocd/resource_test.go
+++ b/gocd/resource_test.go
@@ -21,7 +21,7 @@ func testResourceVersioned(t *testing.T) {
 		"PipelineTemplate":        &PipelineTemplate{Version: "mock-version1"},
 		"PipelineConfigRequest":   &PipelineConfigRequest{Pipeline: &Pipeline{Version: "mock-version1"}},
 		"PipelineTemplateRequest": &PipelineTemplateRequest{Version: "mock-version1"},
-		"Role":                    &Role{Version: "mock-version1"},
+		"Role": &Role{Version: "mock-version1"},
 	}
 	for key, ver := range vers {
 		t.Run(key, func(t *testing.T) {

--- a/gocd/resource_test.go
+++ b/gocd/resource_test.go
@@ -21,6 +21,7 @@ func testResourceVersioned(t *testing.T) {
 		"PipelineTemplate":        &PipelineTemplate{Version: "mock-version1"},
 		"PipelineConfigRequest":   &PipelineConfigRequest{Pipeline: &Pipeline{Version: "mock-version1"}},
 		"PipelineTemplateRequest": &PipelineTemplateRequest{Version: "mock-version1"},
+		"Role":                    &Role{Version: "mock-version1"},
 	}
 	for key, ver := range vers {
 		t.Run(key, func(t *testing.T) {

--- a/gocd/role.go
+++ b/gocd/role.go
@@ -29,7 +29,7 @@ type RoleAttributeProperties struct {
 	Value string `json:"value"`
 }
 
-// RoleListWrapper describes a container for the result of a
+// RoleListWrapper describes a container for the result of a role list operation
 type RoleListWrapper struct {
 	Embedded struct {
 		Roles []*Role `json:"roles"`

--- a/gocd/role.go
+++ b/gocd/role.go
@@ -13,6 +13,7 @@ type Role struct {
 	Name       string              `json:"name"`
 	Type       string              `json:"type"`
 	Attributes *RoleAttributesGoCD `json:"attributes"`
+	Version string `json:"version"`
 }
 
 // RoleAttributesGoCD are attributes describing a role, in this cae, which users are present in the role.

--- a/gocd/role.go
+++ b/gocd/role.go
@@ -23,13 +23,13 @@ type RoleAttributesGoCD struct {
 	Properties   []*RoleAttributeProperties `json:"properties,omitempty"`
 }
 
-// RoleAttributeProperties
+// RoleAttributeProperties describes properties attached to a role
 type RoleAttributeProperties struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
-// RoleListWrapper
+// RoleListWrapper describes a container for the result of a
 type RoleListWrapper struct {
 	Embedded struct {
 		Roles []*Role `json:"roles"`

--- a/gocd/role.go
+++ b/gocd/role.go
@@ -13,7 +13,7 @@ type Role struct {
 	Name       string              `json:"name"`
 	Type       string              `json:"type"`
 	Attributes *RoleAttributesGoCD `json:"attributes"`
-	Version string `json:"version"`
+	Version    string              `json:"version"`
 }
 
 // RoleAttributesGoCD are attributes describing a role, in this cae, which users are present in the role.
@@ -63,6 +63,18 @@ func (rs *RoleService) List(ctx context.Context) (r []*Role, resp *APIResponse, 
 	return wrapper.Embedded.Roles, resp, err
 }
 
+// Get a single role by name
+func (rs *RoleService) Get(ctx context.Context, roleName string) (r *Role, resp *APIResponse, err error) {
+	r = &Role{}
+	_, resp, err = rs.client.getAction(ctx, &APIClientRequest{
+		APIVersion:   apiV1,
+		Path:         fmt.Sprintf("admin/security/roles/%s", roleName),
+		ResponseBody: r,
+	})
+
+	return
+}
+
 // Delete a role by name
 func (rs *RoleService) Delete(ctx context.Context, roleName string) (result bool, resp *APIResponse, err error) {
 	var msg string
@@ -74,6 +86,21 @@ func (rs *RoleService) Delete(ctx context.Context, roleName string) (result bool
 
 	expected := fmt.Sprintf("The role '%s' was deleted successfully.", roleName)
 	result = (expected == msg)
+
+	return
+}
+
+// Update a role by name
+func (rs *RoleService) Update(ctx context.Context, roleName string, role *Role) (
+	r *Role, resp *APIResponse, err error) {
+
+	r = &Role{}
+	_, resp, err = rs.client.putAction(ctx, &APIClientRequest{
+		APIVersion:   apiV1,
+		Path:         fmt.Sprintf("admin/security/roles/%s", roleName),
+		ResponseBody: r,
+		RequestBody:  role,
+	})
 
 	return
 }

--- a/gocd/role_gocd_test.go
+++ b/gocd/role_gocd_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"regexp"
 )
 
 func TestRole(t *testing.T) {
@@ -58,6 +59,10 @@ func testRoleGoCD(t *testing.T) {
 		for _, role := range roles {
 			role_response, _, err := intClient.Roles.Create(ctx, role)
 			assert.NoError(t, err)
+
+			assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), role_response.Version)
+			role.Version = role_response.Version
+
 			assert.Equal(t, role, role_response)
 		}
 
@@ -66,6 +71,9 @@ func testRoleGoCD(t *testing.T) {
 		assert.NoError(t, err)
 
 		for i, role_response := range roles_response {
+			assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), roles[i].Version)
+			role_response.Version = roles[i].Version
+
 			assert.Equal(t, roles[i], role_response)
 		}
 

--- a/gocd/role_gocd_test.go
+++ b/gocd/role_gocd_test.go
@@ -3,8 +3,8 @@ package gocd
 import (
 	"context"
 	"github.com/stretchr/testify/assert"
-	"testing"
 	"regexp"
+	"testing"
 )
 
 func TestRole(t *testing.T) {
@@ -57,25 +57,35 @@ func testRoleGoCD(t *testing.T) {
 
 		// Test role creation
 		for _, role := range roles {
-			role_response, _, err := intClient.Roles.Create(ctx, role)
+			roleResponse, _, err := intClient.Roles.Create(ctx, role)
 			assert.NoError(t, err)
 
-			assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), role_response.Version)
-			role.Version = role_response.Version
+			assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), roleResponse.Version)
+			role.Version = roleResponse.Version
 
-			assert.Equal(t, role, role_response)
+			assert.Equal(t, role, roleResponse)
 		}
 
 		// Test role listing
-		roles_response, _, err := intClient.Roles.List(ctx)
+		rolesResponses, _, err := intClient.Roles.List(ctx)
 		assert.NoError(t, err)
 
-		for i, role_response := range roles_response {
+		for i, roleResponse := range rolesResponses {
 			assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), roles[i].Version)
-			role_response.Version = roles[i].Version
+			roleResponse.Version = roles[i].Version
 
-			assert.Equal(t, roles[i], role_response)
+			assert.Equal(t, roles[i], roleResponse)
 		}
+
+		// Test role update
+		roles[0].Attributes.Users = []string{"new-admin"}
+		roleUpdateResponse, _, err := intClient.Roles.Update(ctx, roles[0].Name, roles[0])
+		assert.NoError(t, err)
+		updatedRole, _, err := intClient.Roles.Get(ctx, roleUpdateResponse.Name)
+		assert.NoError(t, err)
+		assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), updatedRole.Version)
+		roles[0].Version = updatedRole.Version
+		assert.Equal(t, updatedRole, roles[0])
 
 		// Test role delete
 		for _, role := range roles {
@@ -83,9 +93,9 @@ func testRoleGoCD(t *testing.T) {
 			assert.True(t, result)
 			assert.NoError(t, err)
 		}
-		roles_response, _, err = intClient.Roles.List(ctx)
+		roleResponse, _, err := intClient.Roles.List(ctx)
 		assert.NoError(t, err)
-		assert.Empty(t, roles_response)
+		assert.Empty(t, roleResponse)
 
 	} else {
 		skipIntegrationtest(t)


### PR DESCRIPTION
Implemented the role get and role update endpoints

## Description
Implemented the version interface on roles to allow the update endpoint to operate, and updated the get and update endpoints in the roles service.

## Motivation and Context
 - https://github.com/beamly/go-gocd/issues/124
 - https://github.com/beamly/go-gocd/issues/121

## How Has This Been Tested?
Test cases have been added covering this new functionality.