### PR TITLE
Use apiV1 for pause, unpause and releaseLock actions on the pipelines

### DIFF
--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -24,6 +24,8 @@ const (
 	libraryVersion = "1"
 	// UserAgent to be used when calling the GoCD agent.
 	userAgent = "go-gocd/" + libraryVersion
+	// For the unversionned API
+	apiV0 = ""
 	// Version 1 of the GoCD API.
 	apiV1 = "application/vnd.go.cd.v1+json"
 	// Version 2 of the GoCD API.

--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -288,6 +288,16 @@ func (c *Client) Do(ctx context.Context, req *APIRequest, v interface{}, respons
 	return r, err
 }
 
+// getAPIVersion is a wrapper around ServerVersion.GetAPIVersion that starts by making sure ServerVersionService.Get has
+// been called. Note that it also adds the /api/ in front of the provided endpoint
+func (c *Client) getAPIVersion(ctx context.Context, endpoint string) (apiVersion string, err error) {
+	v, _, err := c.ServerVersion.Get(ctx)
+	if err != nil {
+		return "", err
+	}
+	return v.GetAPIVersion(fmt.Sprintf("/api/%s", endpoint))
+}
+
 func readDoResponseBody(v interface{}, bodyReader *io.ReadCloser, responseType string) (body string, err error) {
 	var bodyBytes []byte
 

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -171,7 +171,7 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 	}
 
 	headers := map[string]string{"X-GoCD-Confirm": "true"}
-	if apiVersion == "" {
+	if apiVersion == apiV0 {
 		headers = map[string]string{"Confirm": "true"}
 	}
 

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -165,11 +165,20 @@ func (pgs *PipelinesService) GetHistory(ctx context.Context, name string, offset
 
 func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, action string) (bool, *APIResponse, error) {
 
+	apiVersion, err := pgs.client.getAPIVersion(ctx, fmt.Sprintf("pipelines/:pipeline_name/%s", action))
+	if err != nil {
+		return false, nil, err
+	}
+
+	headers := map[string]string{"X-GoCD-Confirm": "true"}
+	if apiVersion == "" {
+		headers = map[string]string{"Confirm": "true"}
+	}
+
 	_, resp, err := pgs.client.postAction(ctx, &APIClientRequest{
-		Path: fmt.Sprintf("pipelines/%s/%s", name, action),
-		Headers: map[string]string{
-			"Confirm": "true",
-		},
+		Path:       fmt.Sprintf("pipelines/%s/%s", name, action),
+		APIVersion: apiVersion,
+		Headers:    headers,
 	})
 
 	return resp.HTTP.StatusCode == 200, resp, err

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -17,6 +17,7 @@ func testPipelineServicePause(t *testing.T) {
 		{
 			v:             &ServerVersion{Version: "14.3.0"},
 			confirmHeader: "Confirm",
+			acceptHeader:  apiV0,
 		},
 		{
 			v:             &ServerVersion{Version: "18.3.0"},
@@ -56,6 +57,7 @@ func testPipelineServiceUnpause(t *testing.T) {
 		{
 			v:             &ServerVersion{Version: "14.3.0"},
 			confirmHeader: "Confirm",
+			acceptHeader:  apiV0,
 		},
 		{
 			v:             &ServerVersion{Version: "18.3.0"},
@@ -95,6 +97,7 @@ func testPipelineServiceReleaseLock(t *testing.T) {
 		{
 			v:             &ServerVersion{Version: "14.3.0"},
 			confirmHeader: "Confirm",
+			acceptHeader:  apiV0,
 		},
 		{
 			v:             &ServerVersion{Version: "18.3.0"},

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -9,40 +9,118 @@ import (
 )
 
 func testPipelineServicePause(t *testing.T) {
-	mux.HandleFunc("/api/pipelines/test-pipeline/pause", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-		assert.Equal(t, "true", r.Header.Get("Confirm"))
-		fmt.Fprint(w, "")
-	})
-	pp, _, err := client.Pipelines.Pause(context.Background(), "test-pipeline")
-	if err != nil {
-		assert.Nil(t, err)
+	for n, test := range []struct {
+		v             *ServerVersion
+		confirmHeader string
+		acceptHeader  string
+	}{
+		{
+			v:             &ServerVersion{Version: "14.3.0"},
+			confirmHeader: "Confirm",
+		},
+		{
+			v:             &ServerVersion{Version: "18.3.0"},
+			confirmHeader: "X-GoCD-Confirm",
+			acceptHeader:  apiV1,
+		},
+	} {
+		err := test.v.parseVersion()
+		assert.NoError(t, err)
+
+		cachedServerVersion = test.v
+		// defaultHTTPMux doesn't support multiple registrations so change the url a bit
+		mux.HandleFunc(fmt.Sprintf("/api/pipelines/test-pipeline%d/pause", n), func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
+			assert.Equal(t, "true", r.Header.Get(test.confirmHeader))
+			if test.acceptHeader == "" {
+				assert.Equal(t, len(r.Header["Accept"]), 0)
+			} else {
+				assert.Contains(t, r.Header["Accept"], test.acceptHeader)
+			}
+			fmt.Fprint(w, "")
+		})
+		pp, _, err := client.Pipelines.Pause(context.Background(), fmt.Sprintf("test-pipeline%d", n))
+		if err != nil {
+			assert.Nil(t, err)
+		}
+		assert.True(t, pp)
 	}
-	assert.True(t, pp)
 }
 
 func testPipelineServiceUnpause(t *testing.T) {
-	mux.HandleFunc("/api/pipelines/test-pipeline/unpause", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-		assert.Equal(t, "true", r.Header.Get("Confirm"))
-		fmt.Fprint(w, "")
-	})
-	pp, _, err := client.Pipelines.Unpause(context.Background(), "test-pipeline")
-	if err != nil {
-		assert.Nil(t, err)
+	for n, test := range []struct {
+		v             *ServerVersion
+		confirmHeader string
+		acceptHeader  string
+	}{
+		{
+			v:             &ServerVersion{Version: "14.3.0"},
+			confirmHeader: "Confirm",
+		},
+		{
+			v:             &ServerVersion{Version: "18.3.0"},
+			confirmHeader: "X-GoCD-Confirm",
+			acceptHeader:  apiV1,
+		},
+	} {
+		err := test.v.parseVersion()
+		assert.NoError(t, err)
+
+		cachedServerVersion = test.v
+		// defaultHTTPMux doesn't support multiple registrations so change the url a bit
+		mux.HandleFunc(fmt.Sprintf("/api/pipelines/test-pipeline%d/unpause", n), func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
+			assert.Equal(t, "true", r.Header.Get(test.confirmHeader))
+			if test.acceptHeader == "" {
+				assert.Equal(t, len(r.Header["Accept"]), 0)
+			} else {
+				assert.Contains(t, r.Header["Accept"], test.acceptHeader)
+			}
+			fmt.Fprint(w, "")
+		})
+		pp, _, err := client.Pipelines.Unpause(context.Background(), fmt.Sprintf("test-pipeline%d", n))
+		if err != nil {
+			assert.Nil(t, err)
+		}
+		assert.True(t, pp)
 	}
-	assert.True(t, pp)
 }
 
 func testPipelineServiceReleaseLock(t *testing.T) {
-	mux.HandleFunc("/api/pipelines/test-pipeline/releaseLock", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-		assert.Equal(t, "true", r.Header.Get("Confirm"))
-		fmt.Fprint(w, "")
-	})
-	pp, _, err := client.Pipelines.ReleaseLock(context.Background(), "test-pipeline")
-	if err != nil {
-		assert.Nil(t, err)
+	for n, test := range []struct {
+		v             *ServerVersion
+		confirmHeader string
+		acceptHeader  string
+	}{
+		{
+			v:             &ServerVersion{Version: "14.3.0"},
+			confirmHeader: "Confirm",
+		},
+		{
+			v:             &ServerVersion{Version: "18.3.0"},
+			confirmHeader: "X-GoCD-Confirm",
+			acceptHeader:  apiV1,
+		},
+	} {
+		err := test.v.parseVersion()
+		assert.NoError(t, err)
+
+		cachedServerVersion = test.v
+		// defaultHTTPMux doesn't support multiple registrations so change the url a bit
+		mux.HandleFunc(fmt.Sprintf("/api/pipelines/test-pipeline%d/releaseLock", n), func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
+			assert.Equal(t, "true", r.Header.Get(test.confirmHeader))
+			if test.acceptHeader == "" {
+				assert.Equal(t, len(r.Header["Accept"]), 0)
+			} else {
+				assert.Contains(t, r.Header["Accept"], test.acceptHeader)
+			}
+			fmt.Fprint(w, "")
+		})
+		pp, _, err := client.Pipelines.ReleaseLock(context.Background(), fmt.Sprintf("test-pipeline%d", n))
+		if err != nil {
+			assert.Nil(t, err)
+		}
+		assert.True(t, pp)
 	}
-	assert.True(t, pp)
 }

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -19,13 +19,13 @@ func init() {
 				newServerAPI("17.12.0", apiV5),
 				newServerAPI("17.4.0", apiV4)),
 			"/api/pipelines/:pipeline_name/pause": newVersionCollection(
-				newServerAPI("14.3.0", ""),
+				newServerAPI("14.3.0", apiV0),
 				newServerAPI("18.2.0", apiV1)),
 			"/api/pipelines/:pipeline_name/unpause": newVersionCollection(
-				newServerAPI("14.3.0", ""),
+				newServerAPI("14.3.0", apiV0),
 				newServerAPI("18.2.0", apiV1)),
 			"/api/pipelines/:pipeline_name/releaseLock": newVersionCollection(
-				newServerAPI("14.3.0", ""),
+				newServerAPI("14.3.0", apiV0),
 				newServerAPI("18.2.0", apiV1)),
 		},
 	}

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -9,6 +9,7 @@ import (
 var serverVersionLookup *serverVersionCollection
 
 func init() {
+	// This structure lists the version of GoCD in which the corresponding API version is available for a given endpoint
 	serverVersionLookup = &serverVersionCollection{
 		mapping: map[endpointS]*serverAPIVersionMappingCollection{
 			"/api/version": newVersionCollection(
@@ -17,6 +18,15 @@ func init() {
 				newServerAPI("18.7.0", apiV6),
 				newServerAPI("17.12.0", apiV5),
 				newServerAPI("17.4.0", apiV4)),
+			"/api/pipelines/:pipeline_name/pause": newVersionCollection(
+				newServerAPI("14.3.0", ""),
+				newServerAPI("18.2.0", apiV1)),
+			"/api/pipelines/:pipeline_name/unpause": newVersionCollection(
+				newServerAPI("14.3.0", ""),
+				newServerAPI("18.2.0", apiV1)),
+			"/api/pipelines/:pipeline_name/releaseLock": newVersionCollection(
+				newServerAPI("14.3.0", ""),
+				newServerAPI("18.2.0", apiV1)),
 		},
 	}
 }
@@ -99,13 +109,19 @@ func (c *serverAPIVersionMappingCollection) GetAPIVersion(versionParts *version.
 	c.Sort()
 
 	lastMapping := c.mappings[0]
+	// If the minimum version specified is too high or absent, no use to go further
+	if lastMapping == nil || lastMapping.Server.GreaterThan(versionParts) {
+		fmt.Printf("lastMapping.Server: %v -- versionParts: %v\n", lastMapping.Server, versionParts)
+		return "", fmt.Errorf("could not find api version for server version '%s'", versionParts.String())
+	}
 	for _, mapping := range c.mappings {
-		if mapping.Server.GreaterThan(versionParts) || mapping.Server.Equal(versionParts) {
-			return lastMapping.API, nil
+		fmt.Printf("lastMapping.Server: %v -- versionParts: %v\n", lastMapping.Server, versionParts)
+		if mapping.Server.GreaterThan(versionParts) {
+			break
 		}
 		lastMapping = mapping
 	}
-	return "", fmt.Errorf("could not find api version for server version '%s'", versionParts.String())
+	return lastMapping.API, nil
 }
 
 // Sort the version collections

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -9,7 +9,7 @@ import (
 var serverVersionLookup *serverVersionCollection
 
 func init() {
-	// This structure lists the version of GoCD in which the corresponding API version is available for a given endpoint
+	// This structure lists the minimum version of GoCD in which the corresponding API version is available for a given endpoint
 	serverVersionLookup = &serverVersionCollection{
 		mapping: map[endpointS]*serverAPIVersionMappingCollection{
 			"/api/version": newVersionCollection(

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -61,12 +61,22 @@ func testServerVersionGetAPIVersion(t *testing.T) {
 		{
 			endpoint: "/api/version",
 			want:     apiV1,
-			v:        &ServerVersion{Version: "1.0.0"},
+			v:        &ServerVersion{Version: "16.7.0"},
 		},
 		{
 			endpoint: "/api/admin/pipelines/:pipeline_name",
 			want:     apiV5,
 			v:        &ServerVersion{Version: "17.13.0"},
+		},
+		{
+			endpoint: "/api/admin/pipelines/:pipeline_name",
+			want:     apiV6,
+			v:        &ServerVersion{Version: "18.7.0"},
+		},
+		{
+			endpoint: "/api/admin/pipelines/:pipeline_name",
+			want:     apiV6,
+			v:        &ServerVersion{Version: "18.8.0"},
 		},
 	} {
 		test.v.parseVersion()
@@ -84,14 +94,19 @@ func testServerVersionGetAPIVersionFail(t *testing.T) {
 		want     string
 	}{
 		{
+			endpoint: "/api/version",
+			want:     "could not find api version for server version '1.0.0'",
+			v:        &ServerVersion{Version: "1.0.0"},
+		},
+		{
 			endpoint: "/api/foobar",
 			want:     "could not find API version tag for '/api/foobar'",
 			v:        &ServerVersion{Version: "1.0.0"},
 		},
 		{
 			endpoint: "/api/admin/pipelines/:pipeline_name",
-			want:     "could not find api version for server version '100.0.0'",
-			v:        &ServerVersion{Version: "100.0.0"},
+			want:     "could not find api version for server version '0.1.0'",
+			v:        &ServerVersion{Version: "0.1.0"},
 		},
 	} {
 		test.v.parseVersion()


### PR DESCRIPTION
## Description

From gocd release notes: https://www.gocd.org/releases/#18-6-0

> As of release 18.2.0 the following (unversioned) APIs have been deprecated and will be removed in a release scheduled for July 2018:
> - The pipeline pause api.
> - The pipeline unpause api.
> - The pipeline unlock api.
> - The pipeline schedule api.
> 
> These APIs have been replaced with a versioned API and users are encouraged to use these instead.

That means that the current pause/unpause and releaseLock actions won't work anymore when the release 18.7.0 goes out. This is a preventive fix.

Note that with the new versioned API the name of the header is not `Confirm` anymore but `X-GoCD-Confirm`.