### PR TITLE
Add caching to the server version structure

### DIFF
--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+var cachedServerVersion *ServerVersion
+
 type ServerVersionService service
 
 type ServerVersionParts struct {
@@ -25,6 +27,10 @@ type ServerVersion struct {
 
 // Get retrieves information about a specific plugin.
 func (svs *ServerVersionService) Get(ctx context.Context) (v *ServerVersion, resp *APIResponse, err error) {
+	if cachedServerVersion != nil {
+		return cachedServerVersion, nil, nil
+	}
+
 	v = &ServerVersion{}
 	_, resp, err = svs.client.getAction(ctx, &APIClientRequest{
 		Path:         "version",
@@ -54,6 +60,8 @@ func (svs *ServerVersionService) Get(ctx context.Context) (v *ServerVersion, res
 			Patch: patch,
 		}
 	}
+
+	cachedServerVersion = v
 
 	return
 }

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -103,9 +103,10 @@ func testServerVersionCaching(t *testing.T) {
 			Patch: 0,
 		},
 	}
-	v, _, err := client.ServerVersion.Get(context.Background())
+	v, b, err := client.ServerVersion.Get(context.Background())
 
 	assert.NoError(t, err)
+	assert.Nil(t, b)
 
 	assert.Equal(t, &ServerVersion{
 		Version:     "18.7.0",

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -12,6 +12,7 @@ import (
 func TestServerVersion(t *testing.T) {
 	t.Run("ServerVersion", testServerVersion)
 	t.Run("BadServerVersion", testBadServerVersion)
+	t.Run("ServerVersionCaching", testServerVersionCaching)
 }
 
 func testServerVersion(t *testing.T) {
@@ -80,7 +81,6 @@ func testBadServerVersionMajor(t *testing.T, i int, errString string) {
 		fmt.Fprint(w, string(j))
 	})
 
-	cachedServerVersion = nil
 	_, _, err := client.ServerVersion.Get(context.Background())
 
 	assert.EqualError(t, err, errString)


### PR DESCRIPTION
## Description

This PR adds some basic caching mechanism to the server version.

## Motivation and Context

As the server version doesn't change between 2 calls, to avoid doing numerous api calls as we extend our usage of versions, I thought it might be interesting to do some caching of that part.

## How Has This Been Tested?

Added unit tests for it.

Let me know what you think.

Thanks
Joseph
