### PR TITLE
Add Server Version resource

### DIFF
--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -32,6 +32,10 @@ const (
 	apiV3 = "application/vnd.go.cd.v3+json"
 	// Version 4 of the GoCD API.
 	apiV4 = "application/vnd.go.cd.v4+json"
+	// Version 5 of the GoCD API.
+	apiV5 = "application/vnd.go.cd.v5+json"
+	// Version 6 of the GoCD API.
+	apiV6 = "application/vnd.go.cd.v6+json"
 )
 
 //Body Response Types

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -1,0 +1,58 @@
+package gocd
+
+import (
+	"fmt"
+	"strings"
+	"strconv"
+)
+
+func (sv *ServerVersion) GetApiVersion(endpoint string, method string) (apiVersion string, err error) {
+	var hasEndpoint, hasMethod bool
+	var methods map[string]string
+	serverVersionLookup := map[string]interface{}{
+
+	}
+
+	if methods, hasEndpoint = serverVersionLookup[endpoint].(map[string]string); hasEndpoint {
+		if apiVersion, hasMethod = methods[method]; hasMethod {
+			return
+		}
+	}
+
+	return "", fmt.Errorf("could not find API version tag for '%s %s'", method, endpoint)
+}
+
+func (v *ServerVersion) parseVersion() (err error) {
+	var major, minor, patch int
+	versionParts := strings.Split(v.Version, ".")
+
+	if major, err = strconv.Atoi(versionParts[0]); err != nil {
+		return
+	}
+
+	if minor, err = strconv.Atoi(versionParts[1]); err != nil {
+		return
+	}
+
+	if patch, err = strconv.Atoi(versionParts[2]); err != nil {
+		return
+	}
+
+	v.VersionParts = &ServerVersionParts{
+		Major: major,
+		Minor: minor,
+		Patch: patch,
+	}
+	return
+}
+
+// Equal if the two versions are identical
+func (sc *ServerVersion) Equal(v *ServerVersion) bool {
+	return sc.Version == v.Version
+}
+
+func (sc *ServerVersion) LessThan(v *ServerVersion) bool {
+	return sc.VersionParts.Major <= v.VersionParts.Major &&
+		sc.VersionParts.Minor <= v.VersionParts.Minor &&
+		sc.VersionParts.Patch < v.VersionParts.Patch
+}

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 )
 
+// GetApiVersion for a given endpoint and method
 func (sv *ServerVersion) GetApiVersion(endpoint string, method string) (apiVersion string, err error) {
 	var hasEndpoint, hasMethod bool
 	var methods map[string]string
@@ -22,9 +23,9 @@ func (sv *ServerVersion) GetApiVersion(endpoint string, method string) (apiVersi
 	return "", fmt.Errorf("could not find API version tag for '%s %s'", method, endpoint)
 }
 
-func (v *ServerVersion) parseVersion() (err error) {
+func (sv *ServerVersion) parseVersion() (err error) {
 	var major, minor, patch int
-	versionParts := strings.Split(v.Version, ".")
+	versionParts := strings.Split(sv.Version, ".")
 
 	if major, err = strconv.Atoi(versionParts[0]); err != nil {
 		return
@@ -38,7 +39,7 @@ func (v *ServerVersion) parseVersion() (err error) {
 		return
 	}
 
-	v.VersionParts = &ServerVersionParts{
+	sv.VersionParts = &ServerVersionParts{
 		Major: major,
 		Minor: minor,
 		Patch: patch,
@@ -47,12 +48,12 @@ func (v *ServerVersion) parseVersion() (err error) {
 }
 
 // Equal if the two versions are identical
-func (sc *ServerVersion) Equal(v *ServerVersion) bool {
-	return sc.Version == v.Version
+func (sv *ServerVersion) Equal(v *ServerVersion) bool {
+	return sv.Version == v.Version
 }
 
-func (sc *ServerVersion) LessThan(v *ServerVersion) bool {
-	return sc.VersionParts.Major <= v.VersionParts.Major &&
-		sc.VersionParts.Minor <= v.VersionParts.Minor &&
-		sc.VersionParts.Patch < v.VersionParts.Patch
+func (sv *ServerVersion) LessThan(v *ServerVersion) bool {
+	return sv.VersionParts.Major <= v.VersionParts.Major &&
+		sv.VersionParts.Minor <= v.VersionParts.Minor &&
+		sv.VersionParts.Patch < v.VersionParts.Patch
 }

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -13,7 +13,7 @@ func init() {
 		mapping: map[endpointS]*serverAPIVersionMappingCollection{
 			"/api/version": newVersionCollection(
 				newServerAPI("16.6.0", apiV1)),
-			"/go/api/admin/pipelines/:pipeline_name": newVersionCollection(
+			"/api/admin/pipelines/:pipeline_name": newVersionCollection(
 				newServerAPI("18.7.0", apiV6),
 				newServerAPI("17.12.0", apiV5),
 				newServerAPI("17.4.0", apiV4)),
@@ -23,13 +23,13 @@ func init() {
 }
 
 // GetAPIVersion for a given endpoint and method
-func (sv *ServerVersion) GetAPIVersion(endpoint string, method string) (apiVersion string, err error) {
+func (sv *ServerVersion) GetAPIVersion(endpoint string) (apiVersion string, err error) {
 
 	if versions, hasEndpoint := serverVersionLookup.GetEndpointOk(endpoint); hasEndpoint {
 		return versions.GetAPIVersion(sv.VersionParts)
 	}
 
-	return "", fmt.Errorf("could not find API version tag for '%s %s'", method, endpoint)
+	return "", fmt.Errorf("could not find API version tag for '%s'", endpoint)
 }
 
 func (sv *ServerVersion) parseVersion() (err error) {
@@ -107,7 +107,7 @@ func (c *serverAPIVersionMappingCollection) GetAPIVersion(versionParts *version.
 		}
 		lastMapping = mapping
 	}
-	return "", fmt.Errorf("could not find api version")
+	return "", fmt.Errorf("could not find api version for server version '%s'", versionParts.String())
 }
 
 // Sort the version collections

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -48,12 +48,11 @@ func (sv *ServerVersion) LessThan(v *ServerVersion) bool {
 }
 
 //
-// Structures for storing, creating, and parsing the method/endpoint/server-version/api-version mapping
+// Structures for storing, creating, and parsing the endpoint/server-version/api-version mapping
 //
 
 // following type definitions makes the map[...]... below a bit easier to understand.
 type endpointS string
-type methodS string
 
 // serverVersionToAcceptMapping links an Accept header value and a Server version
 type serverVersionToAcceptMapping struct {

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -97,7 +97,7 @@ func (c *ServerApiVersionMappingCollection) Len() int {
 }
 
 func (c *ServerApiVersionMappingCollection) Less(i, j int) bool {
-	return c.mappings[i].Server.LessThan(c.mappings[i].Server)
+	return c.mappings[i].Server.LessThan(c.mappings[j].Server)
 }
 
 func (c *ServerApiVersionMappingCollection) Swap(i, j int) {

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -12,8 +12,20 @@ func init() {
 	serverVersionLookup = newServerVersionLookup().WithEndpoint(
 		"/api/version", newMethodToVersionsMapping().WithMethod(
 			"GET", newServerAPISlice(
-				newServerAPI("1.0.0", apiV1),
-			)))
+				newServerAPI("16.6.0", apiV1),
+			))).WithEndpoint(
+		"/go/api/admin/pipelines/:pipeline_name", newMethodToVersionsMapping().WithMethod(
+			"GET", newServerAPISlice(
+				newServerAPI("18.7.0", apiV6),
+				newServerAPI("17.12.0", apiV5),
+			)).WithMethod(
+			"PUT", newServerAPISlice(
+				newServerAPI("18.7.0", apiV6),
+				newServerAPI("17.12.0", apiV5),
+				newServerAPI("17.4.0", apiV4),
+			),
+		),
+	)
 }
 
 // GetAPIVersion for a given endpoint and method

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -6,111 +6,18 @@ import (
 	"sort"
 )
 
-type serverAPIVersionMapping struct {
-	API    string
-	Server *version.Version
-}
+var serverVersionLookup *serverVersionCollection
 
-func newServerAPIVersionMappingSlice(mappings ...*serverAPIVersionMapping) []*serverAPIVersionMapping {
-	return mappings
-}
-
-func newServerAPIVersionMapping(serverVersion, apiVersion string) (mapping *serverAPIVersionMapping) {
-	mapping = &serverAPIVersionMapping{
-		API: apiVersion,
-	}
-
-	var err error
-	if mapping.Server, err = version.NewVersion(serverVersion); err != nil {
-		panic(err)
-	}
-	return
-}
-
-func newServerVersionCollection() *serverVersionCollection {
-	return &serverVersionCollection{
-		mapping: make(map[string]*serverVersionMethodEndpointMapping),
-	}
-}
-
-type serverVersionCollection struct {
-	mapping map[string]*serverVersionMethodEndpointMapping
-}
-
-func (svc *serverVersionCollection) WithEndpoint(endpoint string, mapping *serverVersionMethodEndpointMapping) *serverVersionCollection {
-	svc.mapping[endpoint] = mapping
-	return svc
-}
-func (svc *serverVersionCollection) GetEndpointOk(endpoint string) (endpointMapping *serverVersionMethodEndpointMapping, hasEndpoint bool) {
-	endpointMapping, hasEndpoint = svc.mapping[endpoint]
-	return
-}
-
-func newServerVersionMethodEndpointMapping() *serverVersionMethodEndpointMapping {
-	return &serverVersionMethodEndpointMapping{
-		methods: make(map[string][]*serverAPIVersionMapping),
-	}
-}
-
-type serverVersionMethodEndpointMapping struct {
-	methods map[string][]*serverAPIVersionMapping
-}
-
-func (svmep *serverVersionMethodEndpointMapping) WithMethod(method string, mappings []*serverAPIVersionMapping) *serverVersionMethodEndpointMapping {
-	svmep.methods[method] = mappings
-	return svmep
-}
-
-func (svmep *serverVersionMethodEndpointMapping) GetMappingOk(method string) (mappings *serverAPIVersionMappingCollection, hasMethod bool) {
-	var mapping []*serverAPIVersionMapping
-	mapping, hasMethod = svmep.methods[method]
-	mappings = &serverAPIVersionMappingCollection{mappings: mapping}
-
-	return
-}
-
-type serverAPIVersionMappingCollection struct {
-	mappings []*serverAPIVersionMapping
-}
-
-// GetAPIVersion for the highest common version
-func (c *serverAPIVersionMappingCollection) GetAPIVersion(versionParts *version.Version) (apiVersion string, err error) {
-	c.Sort()
-
-	lastMapping := c.mappings[0]
-	for _, mapping := range c.mappings {
-		if mapping.Server.GreaterThan(versionParts) || mapping.Server.Equal(versionParts) {
-			return lastMapping.API, nil
-		}
-		lastMapping = mapping
-	}
-	return "", fmt.Errorf("could not find api version")
-}
-
-func (c *serverAPIVersionMappingCollection) Sort() {
-	sort.Sort(c)
-}
-
-func (c *serverAPIVersionMappingCollection) Len() int {
-	return len(c.mappings)
-}
-
-func (c *serverAPIVersionMappingCollection) Less(i, j int) bool {
-	return c.mappings[i].Server.LessThan(c.mappings[j].Server)
-}
-
-func (c *serverAPIVersionMappingCollection) Swap(i, j int) {
-	c.mappings[i], c.mappings[j] = c.mappings[j], c.mappings[i]
+func init() {
+	serverVersionLookup = newServerVersionLookup().WithEndpoint(
+		"/api/version", newMethodToVersionsMapping().WithMethod(
+			"GET", newServerAPISlice(
+				newServerAPI("1.0.0", apiV1),
+			)))
 }
 
 // GetAPIVersion for a given endpoint and method
 func (sv *ServerVersion) GetAPIVersion(endpoint string, method string) (apiVersion string, err error) {
-
-	serverVersionLookup := newServerVersionCollection().WithEndpoint(
-		"/api/version", newServerVersionMethodEndpointMapping().WithMethod(
-			"GET", newServerAPIVersionMappingSlice(
-				newServerAPIVersionMapping("1.0.0", apiV1),
-			)))
 
 	if methods, hasEndpoint := serverVersionLookup.GetEndpointOk(endpoint); hasEndpoint {
 		if versionMapping, hasVersionMapping := methods.GetMappingOk(method); hasVersionMapping {
@@ -134,4 +41,119 @@ func (sv *ServerVersion) Equal(v *ServerVersion) bool {
 // LessThan compares this server version and determines if it is older than the provided server version
 func (sv *ServerVersion) LessThan(v *ServerVersion) bool {
 	return sv.VersionParts.LessThan(v.VersionParts)
+}
+
+//
+// Structures for storing, creating, and parsing the method/endpoint/server-version/api-version mapping
+//
+
+// following type definitions makes the map[...]... below a bit easier to understand.
+type endpointS string
+type methodS string
+
+// serverVersionToAcceptMapping links an Accept header value and a Server version
+type serverVersionToAcceptMapping struct {
+	API    string
+	Server *version.Version
+}
+
+type serverVersionMethodEndpointMapping struct {
+	methods map[methodS][]*serverVersionToAcceptMapping
+}
+
+type serverVersionCollection struct {
+	mapping map[endpointS]*serverVersionMethodEndpointMapping
+}
+
+type serverAPIVersionMappingCollection struct {
+	mappings []*serverVersionToAcceptMapping
+}
+
+// newServerAPISlice provides some syntactic sugar to make the chaining resources a bit easier
+// to read.
+func newServerAPISlice(mappings ...*serverVersionToAcceptMapping) []*serverVersionToAcceptMapping {
+	return mappings
+}
+
+// newServerAPI creates a new server/api version mapping and panics on any errors. These
+// values will be hardcoded, so it should fail when loaded.
+func newServerAPI(serverVersion, apiVersion string) (mapping *serverVersionToAcceptMapping) {
+	mapping = &serverVersionToAcceptMapping{
+		API: apiVersion,
+	}
+
+	var err error
+	if mapping.Server, err = version.NewVersion(serverVersion); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func newServerVersionLookup() *serverVersionCollection {
+	return &serverVersionCollection{
+		mapping: make(map[endpointS]*serverVersionMethodEndpointMapping),
+	}
+}
+
+func (svc *serverVersionCollection) WithEndpoint(endpoint string, mapping *serverVersionMethodEndpointMapping) *serverVersionCollection {
+	svc.mapping[endpointS(endpoint)] = mapping
+	return svc
+}
+
+func (svc *serverVersionCollection) GetEndpointOk(endpoint string) (endpointMapping *serverVersionMethodEndpointMapping, hasEndpoint bool) {
+	endpointMapping, hasEndpoint = svc.mapping[endpointS(endpoint)]
+	return
+}
+
+func newMethodToVersionsMapping() *serverVersionMethodEndpointMapping {
+	return &serverVersionMethodEndpointMapping{
+		methods: make(map[methodS][]*serverVersionToAcceptMapping),
+	}
+}
+
+func (svmep *serverVersionMethodEndpointMapping) WithMethod(method string, mappings []*serverVersionToAcceptMapping) *serverVersionMethodEndpointMapping {
+	svmep.methods[methodS(method)] = mappings
+	return svmep
+}
+
+func (svmep *serverVersionMethodEndpointMapping) GetMappingOk(method string) (mappings *serverAPIVersionMappingCollection, hasMethod bool) {
+	var mapping []*serverVersionToAcceptMapping
+	mapping, hasMethod = svmep.methods[methodS(method)]
+	mappings = &serverAPIVersionMappingCollection{mappings: mapping}
+
+	return
+}
+
+// GetAPIVersion for the highest common version
+func (c *serverAPIVersionMappingCollection) GetAPIVersion(versionParts *version.Version) (apiVersion string, err error) {
+	c.Sort()
+
+	lastMapping := c.mappings[0]
+	for _, mapping := range c.mappings {
+		if mapping.Server.GreaterThan(versionParts) || mapping.Server.Equal(versionParts) {
+			return lastMapping.API, nil
+		}
+		lastMapping = mapping
+	}
+	return "", fmt.Errorf("could not find api version")
+}
+
+// Sort the version collections
+func (c *serverAPIVersionMappingCollection) Sort() {
+	sort.Sort(c)
+}
+
+// Len of the versions in this collection.
+func (c *serverAPIVersionMappingCollection) Len() int {
+	return len(c.mappings)
+}
+
+// Less compares two server versions to see which is lower.
+func (c *serverAPIVersionMappingCollection) Less(i, j int) bool {
+	return c.mappings[i].Server.LessThan(c.mappings[j].Server)
+}
+
+// Swap the position of two server versions.
+func (c *serverAPIVersionMappingCollection) Swap(i, j int) {
+	c.mappings[i], c.mappings[j] = c.mappings[j], c.mappings[i]
 }

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -3,19 +3,119 @@ package gocd
 import (
 	"fmt"
 	"github.com/hashicorp/go-version"
+	"sort"
 )
+
+type ServerApiVersionMapping struct {
+	Api    string
+	Server *version.Version
+}
+
+func NewServerApiVersionMappingSlice(mappings ...*ServerApiVersionMapping) []*ServerApiVersionMapping {
+	return mappings
+}
+
+func NewServerApiVersionMapping(serverVersion, apiVersion string) (mapping *ServerApiVersionMapping) {
+	mapping = &ServerApiVersionMapping{
+		Api: apiVersion,
+	}
+
+	var err error
+	if mapping.Server, err = version.NewVersion(serverVersion); err != nil {
+		panic(err)
+	}
+	return
+}
+
+func NewServerVersionCollection() *ServerVersionCollection {
+	return &ServerVersionCollection{
+		mapping: make(map[string]*ServerVersionMethodEndpointMapping),
+	}
+}
+
+func (svc *ServerVersionCollection) WithEndpoint(endpoint string, mapping *ServerVersionMethodEndpointMapping) *ServerVersionCollection {
+	svc.mapping[endpoint] = mapping
+	return svc
+}
+
+type ServerVersionCollection struct {
+	mapping map[string]*ServerVersionMethodEndpointMapping
+}
+
+func (c *ServerVersionCollection) GetEndpointOk(endpoint string) (endpointMapping *ServerVersionMethodEndpointMapping, hasEndpoint bool) {
+	endpointMapping, hasEndpoint = c.mapping[endpoint]
+	return
+}
+
+func NewServerVersionMethodEndpointMapping() *ServerVersionMethodEndpointMapping {
+	return &ServerVersionMethodEndpointMapping{
+		methods: make(map[string][]*ServerApiVersionMapping),
+	}
+}
+
+func (svmep *ServerVersionMethodEndpointMapping) WithMethod(method string, mappings []*ServerApiVersionMapping) *ServerVersionMethodEndpointMapping {
+	svmep.methods[method] = mappings
+	return svmep
+}
+
+type ServerVersionMethodEndpointMapping struct {
+	methods map[string][]*ServerApiVersionMapping
+}
+
+func (m *ServerVersionMethodEndpointMapping) GetMappingOk(method string) (mappings *ServerApiVersionMappingCollection, hasMethod bool) {
+	var mapping []*ServerApiVersionMapping
+	mapping, hasMethod = m.methods[method]
+	mappings = &ServerApiVersionMappingCollection{mappings: mapping}
+
+	return
+}
+
+type ServerApiVersionMappingCollection struct {
+	mappings []*ServerApiVersionMapping
+}
+
+// GetApiVersion for the highest common version
+func (c *ServerApiVersionMappingCollection) GetApiVersion(versionParts *version.Version) (apiVersion string, err error) {
+	c.Sort()
+
+	lastMapping := c.mappings[0]
+	for _, mapping := range c.mappings {
+		if mapping.Server.GreaterThan(versionParts) || mapping.Server.Equal(versionParts) {
+			return lastMapping.Api, nil
+		}
+		lastMapping = mapping
+	}
+	return "", fmt.Errorf("could not find api version")
+}
+
+func (c *ServerApiVersionMappingCollection) Sort() {
+	sort.Sort(c)
+}
+
+func (c *ServerApiVersionMappingCollection) Len() int {
+	return len(c.mappings)
+}
+
+func (c *ServerApiVersionMappingCollection) Less(i, j int) bool {
+	return c.mappings[i].Server.LessThan(c.mappings[i].Server)
+}
+
+func (c *ServerApiVersionMappingCollection) Swap(i, j int) {
+	c.mappings[i], c.mappings[j] = c.mappings[j], c.mappings[i]
+}
 
 // GetAPIVersion for a given endpoint and method
 func (sv *ServerVersion) GetAPIVersion(endpoint string, method string) (apiVersion string, err error) {
-	var hasEndpoint, hasMethod bool
-	var methods map[string]string
-	serverVersionLookup := map[string]interface{}{
-		"/api/version": map[string]string{"GET": apiV1},
-	}
 
-	if methods, hasEndpoint = serverVersionLookup[endpoint].(map[string]string); hasEndpoint {
-		if apiVersion, hasMethod = methods[method]; hasMethod {
-			return apiVersion, nil
+	serverVersionLookup := NewServerVersionCollection().WithEndpoint(
+		"/api/version", NewServerVersionMethodEndpointMapping().WithMethod(
+			"GET", NewServerApiVersionMappingSlice(
+				NewServerApiVersionMapping("1.0.0", apiV1),
+			)))
+
+	if methods, hasEndpoint := serverVersionLookup.GetEndpointOk(endpoint); hasEndpoint {
+		if versionMapping, hasVersionMapping := methods.GetMappingOk(method); hasVersionMapping {
+			return versionMapping.GetApiVersion(sv.VersionParts)
 		}
 	}
 

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// GetApiVersion for a given endpoint and method
-func (sv *ServerVersion) GetApiVersion(endpoint string, method string) (apiVersion string, err error) {
+// GetAPIVersion for a given endpoint and method
+func (sv *ServerVersion) GetAPIVersion(endpoint string, method string) (apiVersion string, err error) {
 	var hasEndpoint, hasMethod bool
 	var methods map[string]string
 	serverVersionLookup := map[string]interface{}{}
@@ -50,6 +50,7 @@ func (sv *ServerVersion) Equal(v *ServerVersion) bool {
 	return sv.Version == v.Version
 }
 
+// LessThan compares this server version and determines if it is older than the provided server version
 func (sv *ServerVersion) LessThan(v *ServerVersion) bool {
 	return sv.VersionParts.Major <= v.VersionParts.Major &&
 		sv.VersionParts.Minor <= v.VersionParts.Minor &&

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -2,17 +2,15 @@ package gocd
 
 import (
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // GetApiVersion for a given endpoint and method
 func (sv *ServerVersion) GetApiVersion(endpoint string, method string) (apiVersion string, err error) {
 	var hasEndpoint, hasMethod bool
 	var methods map[string]string
-	serverVersionLookup := map[string]interface{}{
-
-	}
+	serverVersionLookup := map[string]interface{}{}
 
 	if methods, hasEndpoint = serverVersionLookup[endpoint].(map[string]string); hasEndpoint {
 		if apiVersion, hasMethod = methods[method]; hasMethod {

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -10,9 +10,7 @@ func (sv *ServerVersion) GetAPIVersion(endpoint string, method string) (apiVersi
 	var hasEndpoint, hasMethod bool
 	var methods map[string]string
 	serverVersionLookup := map[string]interface{}{
-		"/api/version": map[string]string{
-			"GET": apiV1,
-		},
+		"/api/version": map[string]string{"GET": apiV1},
 	}
 
 	if methods, hasEndpoint = serverVersionLookup[endpoint].(map[string]string); hasEndpoint {

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -1,0 +1,43 @@
+package gocd
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func testServerVersionResource(t *testing.T) {
+	t.Run("LessThan", testServerVersionLessThan)
+	t.Run("Equal", testServerVersionEqual)
+}
+
+func testServerVersionEqual(t *testing.T) {
+	for _, test := range []struct {
+		v1   *ServerVersion
+		v2   *ServerVersion
+		want bool
+	}{
+		{v1: &ServerVersion{Version: "1.2.3"}, v2: &ServerVersion{Version: "1.2.3"}, want: true},
+		{v1: &ServerVersion{Version: "1.2.3"}, v2: &ServerVersion{Version: "2.2.3"}, want: false},
+	} {
+		assert.Equal(t, test.want, test.v1.Equal(test.v2))
+		assert.Equal(t, test.want, test.v2.Equal(test.v1))
+	}
+}
+
+func testServerVersionLessThan(t *testing.T) {
+	for _, test := range []struct {
+		v1   *ServerVersion
+		v2   *ServerVersion
+		want bool
+	}{
+		{v1: &ServerVersion{Version: "1.0.0"}, v2: &ServerVersion{Version: "2.0.0"}, want: true},
+		{v1: &ServerVersion{Version: "2.0.1"}, v2: &ServerVersion{Version: "2.0.0"}, want: true},
+		{v1: &ServerVersion{Version: "2.0.0"}, v2: &ServerVersion{Version: "1.0.0"}, want: false},
+	} {
+		test.v1.parseVersion()
+		test.v2.parseVersion()
+
+		assert.Equal(t, test.want, test.v1.LessThan(test.v2))
+		assert.Equal(t, !test.want, test.v2.LessThan(test.v1))
+	}
+}

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -2,12 +2,16 @@ package gocd
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
+	"net/http"
 )
 
 func testServerVersionResource(t *testing.T) {
 	t.Run("LessThan", testServerVersionLessThan)
 	t.Run("Equal", testServerVersionEqual)
+	t.Run("GetApiVersion", testServerVersionGetApiVersion)
+	t.Run("GetApiVersionFail", testServerVersionGetApiVersionFail)
 }
 
 func testServerVersionEqual(t *testing.T) {
@@ -31,7 +35,8 @@ func testServerVersionLessThan(t *testing.T) {
 		want bool
 	}{
 		{v1: &ServerVersion{Version: "1.0.0"}, v2: &ServerVersion{Version: "2.0.0"}, want: true},
-		{v1: &ServerVersion{Version: "2.0.1"}, v2: &ServerVersion{Version: "2.0.0"}, want: true},
+		{v1: &ServerVersion{Version: "2.0.1"}, v2: &ServerVersion{Version: "2.0.0"}, want: false},
+		{v1: &ServerVersion{Version: "2.0.0"}, v2: &ServerVersion{Version: "2.0.1"}, want: true},
 		{v1: &ServerVersion{Version: "2.0.0"}, v2: &ServerVersion{Version: "1.0.0"}, want: false},
 	} {
 		test.v1.parseVersion()
@@ -39,5 +44,45 @@ func testServerVersionLessThan(t *testing.T) {
 
 		assert.Equal(t, test.want, test.v1.LessThan(test.v2))
 		assert.Equal(t, !test.want, test.v2.LessThan(test.v1))
+	}
+}
+
+func testServerVersionGetApiVersion(t *testing.T) {
+	for _, test := range []struct {
+		v        *ServerVersion
+		endpoint string
+		method   string
+		want     string
+	}{
+		{
+			endpoint: "/api/version",
+			method:   http.MethodGet,
+			want:     apiV1,
+		},
+	} {
+		apiV, err := test.v.GetApiVersion(test.endpoint, test.method)
+
+		assert.NoError(t, err)
+		assert.Equal(t, apiV, test.want)
+	}
+}
+
+func testServerVersionGetApiVersionFail(t *testing.T) {
+	for _, test := range []struct {
+		v        *ServerVersion
+		endpoint string
+		method   string
+		want     string
+	}{
+		{
+			endpoint: "/api/foobar",
+			method:   http.MethodGet,
+			want:     apiV1,
+		},
+	} {
+		apiV, err := test.v.GetApiVersion(test.endpoint, test.method)
+
+		assert.EqualError(t, err, test.want)
+		assert.Empty(t, apiV)
 	}
 }

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -3,6 +3,7 @@ package gocd
 import (
 	"testing"
 
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 )
@@ -39,11 +40,15 @@ func testServerVersionLessThan(t *testing.T) {
 		{v1: &ServerVersion{Version: "2.0.0"}, v2: &ServerVersion{Version: "2.0.1"}, want: true},
 		{v1: &ServerVersion{Version: "2.0.0"}, v2: &ServerVersion{Version: "1.0.0"}, want: false},
 	} {
-		test.v1.parseVersion()
-		test.v2.parseVersion()
+		name := fmt.Sprintf("%s < %s = %t", test.v1.Version, test.v2.Version, test.want)
+		t.Run(name, func(t *testing.T) {
 
-		assert.Equal(t, test.want, test.v1.LessThan(test.v2))
-		assert.Equal(t, !test.want, test.v2.LessThan(test.v1))
+			test.v1.parseVersion()
+			test.v2.parseVersion()
+
+			assert.Equal(t, test.want, test.v1.LessThan(test.v2))
+			assert.Equal(t, !test.want, test.v2.LessThan(test.v1))
+		})
 	}
 }
 
@@ -77,7 +82,7 @@ func testServerVersionGetAPIVersionFail(t *testing.T) {
 		{
 			endpoint: "/api/foobar",
 			method:   http.MethodGet,
-			want:     apiV1,
+			want:     "could not find API version tag for 'GET /api/foobar'",
 		},
 	} {
 		apiV, err := test.v.GetAPIVersion(test.endpoint, test.method)

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -106,12 +106,12 @@ func TestNewserverAPIVersionMapping(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        args
-		wantMapping *serverAPIVersionMapping
+		wantMapping *serverVersionToAcceptMapping
 	}{
 		{
 			name: "base",
 			args: args{serverVersion: "1.0.0", apiVersion: apiV1},
-			wantMapping: &serverAPIVersionMapping{
+			wantMapping: &serverVersionToAcceptMapping{
 				API:    apiV1,
 				Server: mockVersion,
 			},
@@ -121,7 +121,7 @@ func TestNewserverAPIVersionMapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t,
 				tt.wantMapping,
-				newServerAPIVersionMapping(tt.args.serverVersion, tt.args.apiVersion),
+				newServerAPI(tt.args.serverVersion, tt.args.apiVersion),
 			)
 		})
 	}
@@ -130,22 +130,22 @@ func TestNewserverAPIVersionMapping(t *testing.T) {
 func TestServerAPIVersionMappingCollection_Sort(t *testing.T) {
 	tests := []struct {
 		name     string
-		mappings []*serverAPIVersionMapping
-		want     []*serverAPIVersionMapping
+		mappings []*serverVersionToAcceptMapping
+		want     []*serverVersionToAcceptMapping
 	}{
 		{
 			name: "base",
-			mappings: newServerAPIVersionMappingSlice(
-				newServerAPIVersionMapping("2.0.0", apiV2),
-				newServerAPIVersionMapping("1.0.0", apiV1),
-				newServerAPIVersionMapping("4.0.0", apiV4),
-				newServerAPIVersionMapping("3.0.0", apiV3),
+			mappings: newServerAPISlice(
+				newServerAPI("2.0.0", apiV2),
+				newServerAPI("1.0.0", apiV1),
+				newServerAPI("4.0.0", apiV4),
+				newServerAPI("3.0.0", apiV3),
 			),
-			want: newServerAPIVersionMappingSlice(
-				newServerAPIVersionMapping("1.0.0", apiV1),
-				newServerAPIVersionMapping("2.0.0", apiV2),
-				newServerAPIVersionMapping("3.0.0", apiV3),
-				newServerAPIVersionMapping("4.0.0", apiV4),
+			want: newServerAPISlice(
+				newServerAPI("1.0.0", apiV1),
+				newServerAPI("2.0.0", apiV2),
+				newServerAPI("3.0.0", apiV3),
+				newServerAPI("4.0.0", apiV4),
 			),
 		},
 	}

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
 )
 
 func testServerVersionResource(t *testing.T) {

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -95,7 +95,7 @@ func testServerVersionGetAPIVersionFail(t *testing.T) {
 	}
 }
 
-func TestNewServerApiVersionMapping(t *testing.T) {
+func TestNewserverAPIVersionMapping(t *testing.T) {
 
 	mockVersion, err := version.NewVersion("1.0.0")
 	assert.NoError(t, err)
@@ -106,13 +106,13 @@ func TestNewServerApiVersionMapping(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        args
-		wantMapping *ServerApiVersionMapping
+		wantMapping *serverAPIVersionMapping
 	}{
 		{
 			name: "base",
 			args: args{serverVersion: "1.0.0", apiVersion: apiV1},
-			wantMapping: &ServerApiVersionMapping{
-				Api:    apiV1,
+			wantMapping: &serverAPIVersionMapping{
+				API:    apiV1,
 				Server: mockVersion,
 			},
 		},
@@ -121,43 +121,38 @@ func TestNewServerApiVersionMapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t,
 				tt.wantMapping,
-				NewServerApiVersionMapping(tt.args.serverVersion, tt.args.apiVersion),
+				newServerAPIVersionMapping(tt.args.serverVersion, tt.args.apiVersion),
 			)
 		})
 	}
 }
 
-func TestServerApiVersionMappingCollection_Sort(t *testing.T) {
-	type fields struct {
-		mappings []*ServerApiVersionMapping
-	}
+func TestServerAPIVersionMappingCollection_Sort(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields fields
-		want   []*ServerApiVersionMapping
+		name     string
+		mappings []*serverAPIVersionMapping
+		want     []*serverAPIVersionMapping
 	}{
 		{
 			name: "base",
-			fields: fields{
-				mappings: NewServerApiVersionMappingSlice(
-					NewServerApiVersionMapping("2.0.0", apiV2),
-					NewServerApiVersionMapping("1.0.0", apiV1),
-					NewServerApiVersionMapping("4.0.0", apiV4),
-					NewServerApiVersionMapping("3.0.0", apiV3),
-				),
-			},
-			want: NewServerApiVersionMappingSlice(
-				NewServerApiVersionMapping("1.0.0", apiV1),
-				NewServerApiVersionMapping("2.0.0", apiV2),
-				NewServerApiVersionMapping("3.0.0", apiV3),
-				NewServerApiVersionMapping("4.0.0", apiV4),
+			mappings: newServerAPIVersionMappingSlice(
+				newServerAPIVersionMapping("2.0.0", apiV2),
+				newServerAPIVersionMapping("1.0.0", apiV1),
+				newServerAPIVersionMapping("4.0.0", apiV4),
+				newServerAPIVersionMapping("3.0.0", apiV3),
+			),
+			want: newServerAPIVersionMappingSlice(
+				newServerAPIVersionMapping("1.0.0", apiV1),
+				newServerAPIVersionMapping("2.0.0", apiV2),
+				newServerAPIVersionMapping("3.0.0", apiV3),
+				newServerAPIVersionMapping("4.0.0", apiV4),
 			),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &ServerApiVersionMappingCollection{
-				mappings: tt.fields.mappings,
+			c := &serverAPIVersionMappingCollection{
+				mappings: tt.mappings,
 			}
 			c.Sort()
 			assert.Equal(t, tt.want, c.mappings)

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -129,33 +129,34 @@ func TestNewserverAPIVersionMapping(t *testing.T) {
 
 func TestServerAPIVersionMappingCollection_Sort(t *testing.T) {
 	tests := []struct {
-		name     string
-		mappings []*serverVersionToAcceptMapping
-		want     []*serverVersionToAcceptMapping
+		name string
+		have *serverAPIVersionMappingCollection
+		want *serverAPIVersionMappingCollection
 	}{
 		{
 			name: "base",
-			mappings: newServerAPISlice(
-				newServerAPI("2.0.0", apiV2),
-				newServerAPI("1.0.0", apiV1),
-				newServerAPI("4.0.0", apiV4),
-				newServerAPI("3.0.0", apiV3),
-			),
-			want: newServerAPISlice(
-				newServerAPI("1.0.0", apiV1),
-				newServerAPI("2.0.0", apiV2),
-				newServerAPI("3.0.0", apiV3),
-				newServerAPI("4.0.0", apiV4),
-			),
+			have: &serverAPIVersionMappingCollection{
+				mappings: []*serverVersionToAcceptMapping{
+					newServerAPI("2.0.0", apiV2),
+					newServerAPI("1.0.0", apiV1),
+					newServerAPI("4.0.0", apiV4),
+					newServerAPI("3.0.0", apiV3),
+				},
+			},
+			want: &serverAPIVersionMappingCollection{
+				mappings: []*serverVersionToAcceptMapping{
+					newServerAPI("1.0.0", apiV1),
+					newServerAPI("2.0.0", apiV2),
+					newServerAPI("3.0.0", apiV3),
+					newServerAPI("4.0.0", apiV4),
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &serverAPIVersionMappingCollection{
-				mappings: tt.mappings,
-			}
-			c.Sort()
-			assert.Equal(t, tt.want, c.mappings)
+			tt.have.Sort()
+			assert.Equal(t, tt.want, tt.have)
 		})
 	}
 }

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -126,3 +126,41 @@ func TestNewServerApiVersionMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestServerApiVersionMappingCollection_Sort(t *testing.T) {
+	type fields struct {
+		mappings []*ServerApiVersionMapping
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []*ServerApiVersionMapping
+	}{
+		{
+			name: "base",
+			fields: fields{
+				mappings: NewServerApiVersionMappingSlice(
+					NewServerApiVersionMapping("2.0.0", apiV2),
+					NewServerApiVersionMapping("1.0.0", apiV1),
+					NewServerApiVersionMapping("4.0.0", apiV4),
+					NewServerApiVersionMapping("3.0.0", apiV3),
+				),
+			},
+			want: NewServerApiVersionMappingSlice(
+				NewServerApiVersionMapping("1.0.0", apiV1),
+				NewServerApiVersionMapping("2.0.0", apiV2),
+				NewServerApiVersionMapping("3.0.0", apiV3),
+				NewServerApiVersionMapping("4.0.0", apiV4),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ServerApiVersionMappingCollection{
+				mappings: tt.fields.mappings,
+			}
+			c.Sort()
+			assert.Equal(t, tt.want, c.mappings)
+		})
+	}
+}

--- a/gocd/resource_server_version_test.go
+++ b/gocd/resource_server_version_test.go
@@ -10,8 +10,8 @@ import (
 func testServerVersionResource(t *testing.T) {
 	t.Run("LessThan", testServerVersionLessThan)
 	t.Run("Equal", testServerVersionEqual)
-	t.Run("GetApiVersion", testServerVersionGetApiVersion)
-	t.Run("GetApiVersionFail", testServerVersionGetApiVersionFail)
+	t.Run("GetAPIVersion", testServerVersionGetAPIVersion)
+	t.Run("GetAPIVersionFail", testServerVersionGetAPIVersionFail)
 }
 
 func testServerVersionEqual(t *testing.T) {
@@ -47,7 +47,7 @@ func testServerVersionLessThan(t *testing.T) {
 	}
 }
 
-func testServerVersionGetApiVersion(t *testing.T) {
+func testServerVersionGetAPIVersion(t *testing.T) {
 	for _, test := range []struct {
 		v        *ServerVersion
 		endpoint string
@@ -60,14 +60,14 @@ func testServerVersionGetApiVersion(t *testing.T) {
 			want:     apiV1,
 		},
 	} {
-		apiV, err := test.v.GetApiVersion(test.endpoint, test.method)
+		apiV, err := test.v.GetAPIVersion(test.endpoint, test.method)
 
 		assert.NoError(t, err)
 		assert.Equal(t, apiV, test.want)
 	}
 }
 
-func testServerVersionGetApiVersionFail(t *testing.T) {
+func testServerVersionGetAPIVersionFail(t *testing.T) {
 	for _, test := range []struct {
 		v        *ServerVersion
 		endpoint string
@@ -80,7 +80,7 @@ func testServerVersionGetApiVersionFail(t *testing.T) {
 			want:     apiV1,
 		},
 	} {
-		apiV, err := test.v.GetApiVersion(test.endpoint, test.method)
+		apiV, err := test.v.GetAPIVersion(test.endpoint, test.method)
 
 		assert.EqualError(t, err, test.want)
 		assert.Empty(t, apiV)

--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -2,8 +2,6 @@ package gocd
 
 import (
 	"context"
-	"strconv"
-	"strings"
 )
 
 var cachedServerVersion *ServerVersion
@@ -38,28 +36,7 @@ func (svs *ServerVersionService) Get(ctx context.Context) (v *ServerVersion, res
 		APIVersion:   apiV1,
 	})
 
-	if err == nil {
-		var major, minor, patch int
-		versionParts := strings.Split(v.Version, ".")
-
-		if major, err = strconv.Atoi(versionParts[0]); err != nil {
-			return
-		}
-
-		if minor, err = strconv.Atoi(versionParts[1]); err != nil {
-			return
-		}
-
-		if patch, err = strconv.Atoi(versionParts[2]); err != nil {
-			return
-		}
-
-		v.VersionParts = &ServerVersionParts{
-			Major: major,
-			Minor: minor,
-			Patch: patch,
-		}
-	}
+	err = v.parseVersion()
 
 	cachedServerVersion = v
 

--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -4,16 +4,19 @@ import (
 	"context"
 )
 
-var cachedServerVersion *ServerVersion
-
+// ServerVersionService exposes calls for interacting with ServerVersion objects in the GoCD API.
 type ServerVersionService service
 
+var cachedServerVersion *ServerVersion
+
+// ServerVersionParts is composed of the semantic version parts of the server version
 type ServerVersionParts struct {
 	Major int
 	Minor int
 	Patch int
 }
 
+// ServerVersion of the GoCD installation
 type ServerVersion struct {
 	Version      string `json:"version"`
 	VersionParts *ServerVersionParts

--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -2,6 +2,7 @@ package gocd
 
 import (
 	"context"
+	"github.com/hashicorp/go-version"
 )
 
 // ServerVersionService exposes calls for interacting with ServerVersion objects in the GoCD API.
@@ -9,17 +10,10 @@ type ServerVersionService service
 
 var cachedServerVersion *ServerVersion
 
-// ServerVersionParts is composed of the semantic version parts of the server version
-type ServerVersionParts struct {
-	Major int
-	Minor int
-	Patch int
-}
-
 // ServerVersion of the GoCD installation
 type ServerVersion struct {
 	Version      string `json:"version"`
-	VersionParts *ServerVersionParts
+	VersionParts *version.Version
 	BuildNumber  string `json:"build_number"`
 	GitSha       string `json:"git_sha"`
 	FullVersion  string `json:"full_version"`

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -2,10 +2,7 @@ package gocd
 
 import (
 	"context"
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"net/http"
 	"testing"
 )
 
@@ -17,39 +14,30 @@ func TestServerVersion(t *testing.T) {
 }
 
 func testServerVersion(t *testing.T) {
-	setup()
-	defer teardown()
 
-	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Equal(t, apiV1, r.Header.Get("Accept"))
+	if runIntegrationTest() {
 
-		j, _ := ioutil.ReadFile("test/resources/server-version.v1.1.json")
+		cachedServerVersion = nil
+		v, _, err := client.ServerVersion.Get(context.Background())
 
-		fmt.Fprint(w, string(j))
-	})
+		assert.NoError(t, err)
 
-	cachedServerVersion = nil
-	v, _, err := client.ServerVersion.Get(context.Background())
+		assert.Equal(t, &ServerVersion{
+			Version:     "16.6.0",
+			BuildNumber: "3348",
+			GitSha:      "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+			FullVersion: "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+			CommitURL:   "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
+			VersionParts: &ServerVersionParts{
+				Major: 16,
+				Minor: 6,
+				Patch: 0,
+			},
+		}, v)
 
-	assert.NoError(t, err)
-
-	assert.Equal(t, &ServerVersion{
-		Version:     "16.6.0",
-		BuildNumber: "3348",
-		GitSha:      "a7a5717cbd60c30006314fb8dd529796c93adaf0",
-		FullVersion: "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
-		CommitURL:   "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
-		VersionParts: &ServerVersionParts{
-			Major: 16,
-			Minor: 6,
-			Patch: 0,
-		},
-	}, v)
-
-	// Verify that the server version is cached
-	assert.Equal(t, cachedServerVersion, v)
-
+		// Verify that the server version is cached
+		assert.Equal(t, cachedServerVersion, v)
+	}
 }
 
 func testBadServerVersion(t *testing.T) {
@@ -68,29 +56,13 @@ func testBadServerVersion(t *testing.T) {
 }
 
 func testBadServerVersionMajor(t *testing.T, i int, errString string) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Equal(t, apiV1, r.Header.Get("Accept"))
-
-		j, _ := ioutil.ReadFile(
-			fmt.Sprintf("test/resources/server-version.v1.%d.json", i),
-		)
-
-		fmt.Fprint(w, string(j))
-	})
-
-	_, _, err := client.ServerVersion.Get(context.Background())
-
-	assert.EqualError(t, err, errString)
+	if runIntegrationTest() {
+		_, _, err := client.ServerVersion.Get(context.Background())
+		assert.EqualError(t, err, errString)
+	}
 }
 
 func testServerVersionCaching(t *testing.T) {
-	setup()
-	defer teardown()
-	// Note that this test should not do an API call
 
 	cachedServerVersion = &ServerVersion{
 		Version:     "18.7.0",

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -13,6 +13,7 @@ func TestServerVersion(t *testing.T) {
 	t.Run("ServerVersion", testServerVersion)
 	t.Run("BadServerVersion", testBadServerVersion)
 	t.Run("ServerVersionCaching", testServerVersionCaching)
+	t.Run("Resource", testServerVersionResource)
 }
 
 func testServerVersion(t *testing.T) {

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -15,6 +15,7 @@ func TestServerVersion(t *testing.T) {
 }
 
 func testServerVersion(t *testing.T) {
+	intSetup()
 
 	if runIntegrationTest() {
 
@@ -56,6 +57,7 @@ func testBadServerVersion(t *testing.T) {
 }
 
 func testBadServerVersionMajor(t *testing.T, i int, errString string) {
+	intSetup()
 	if runIntegrationTest() {
 		_, _, err := client.ServerVersion.Get(context.Background())
 		assert.EqualError(t, err, errString)
@@ -63,28 +65,31 @@ func testBadServerVersionMajor(t *testing.T, i int, errString string) {
 }
 
 func testServerVersionCaching(t *testing.T) {
-	ver, err := version.NewVersion("18.7.0")
-	assert.NoError(t, err)
+	intSetup()
+	if runIntegrationTest() {
+		ver, err := version.NewVersion("18.7.0")
+		assert.NoError(t, err)
 
-	cachedServerVersion = &ServerVersion{
-		Version:      "18.7.0",
-		BuildNumber:  "7121",
-		GitSha:       "75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		FullVersion:  "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
-		CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		VersionParts: ver,
+		cachedServerVersion = &ServerVersion{
+			Version:      "18.7.0",
+			BuildNumber:  "7121",
+			GitSha:       "75d1247f58ab8bcde3c5b43392a87347979f82c5",
+			FullVersion:  "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
+			CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
+			VersionParts: ver,
+		}
+		v, b, err := client.ServerVersion.Get(context.Background())
+
+		assert.NoError(t, err)
+		assert.Nil(t, b)
+
+		assert.Equal(t, &ServerVersion{
+			Version:      "18.7.0",
+			BuildNumber:  "7121",
+			GitSha:       "75d1247f58ab8bcde3c5b43392a87347979f82c5",
+			FullVersion:  "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
+			CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
+			VersionParts: ver,
+		}, v)
 	}
-	v, b, err := client.ServerVersion.Get(context.Background())
-
-	assert.NoError(t, err)
-	assert.Nil(t, b)
-
-	assert.Equal(t, &ServerVersion{
-		Version:      "18.7.0",
-		BuildNumber:  "7121",
-		GitSha:       "75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		FullVersion:  "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
-		CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		VersionParts: ver,
-	}, v)
 }

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -8,64 +8,11 @@ import (
 )
 
 func TestServerVersion(t *testing.T) {
-	t.Run("ServerVersion", testServerVersion)
-	t.Run("BadServerVersion", testBadServerVersion)
 	t.Run("ServerVersionCaching", testServerVersionCaching)
 	t.Run("Resource", testServerVersionResource)
 }
 
-func testServerVersion(t *testing.T) {
-	intSetup()
-
-	if runIntegrationTest() {
-
-		cachedServerVersion = nil
-		v, _, err := client.ServerVersion.Get(context.Background())
-
-		assert.NoError(t, err)
-
-		ver, err := version.NewVersion("16.6.0")
-		assert.NoError(t, err)
-
-		assert.Equal(t, &ServerVersion{
-			Version:      "16.6.0",
-			BuildNumber:  "3348",
-			GitSha:       "a7a5717cbd60c30006314fb8dd529796c93adaf0",
-			FullVersion:  "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
-			CommitURL:    "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
-			VersionParts: ver,
-		}, v)
-
-		// Verify that the server version is cached
-		assert.Equal(t, cachedServerVersion, v)
-	}
-}
-
-func testBadServerVersion(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		id        int
-		errString string
-	}{
-		{name: "Major", id: 2, errString: "strconv.Atoi: parsing \"a\": invalid syntax"},
-		{name: "Minor", id: 3, errString: "strconv.Atoi: parsing \"b\": invalid syntax"},
-		{name: "Patch", id: 4, errString: "strconv.Atoi: parsing \"c\": invalid syntax"},
-	} {
-		cachedServerVersion = nil
-		t.Run(test.name, func(t *testing.T) { testBadServerVersionMajor(t, test.id, test.errString) })
-	}
-}
-
-func testBadServerVersionMajor(t *testing.T, i int, errString string) {
-	intSetup()
-	if runIntegrationTest() {
-		_, _, err := client.ServerVersion.Get(context.Background())
-		assert.EqualError(t, err, errString)
-	}
-}
-
 func testServerVersionCaching(t *testing.T) {
-	intSetup()
 	if runIntegrationTest() {
 		ver, err := version.NewVersion("18.7.0")
 		assert.NoError(t, err)
@@ -78,7 +25,7 @@ func testServerVersionCaching(t *testing.T) {
 			CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
 			VersionParts: ver,
 		}
-		v, b, err := client.ServerVersion.Get(context.Background())
+		v, b, err := intClient.ServerVersion.Get(context.Background())
 
 		assert.NoError(t, err)
 		assert.Nil(t, b)

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -2,12 +2,12 @@ package gocd
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"net/http"
 	"io/ioutil"
-	"fmt"
+	"net/http"
+	"testing"
 )
 
 func TestServerVersion(t *testing.T) {
@@ -45,7 +45,7 @@ func testServerVersion(t *testing.T) {
 		VersionParts: ver,
 	}, v)
 
-	// Verify that the server version is cached	
+	// Verify that the server version is cached
 	assert.Equal(t, cachedServerVersion, v)
 
 }

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -2,6 +2,7 @@ package gocd
 
 import (
 	"context"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -22,17 +23,16 @@ func testServerVersion(t *testing.T) {
 
 		assert.NoError(t, err)
 
+		ver, err := version.NewVersion("16.6.0")
+		assert.NoError(t, err)
+
 		assert.Equal(t, &ServerVersion{
-			Version:     "16.6.0",
-			BuildNumber: "3348",
-			GitSha:      "a7a5717cbd60c30006314fb8dd529796c93adaf0",
-			FullVersion: "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
-			CommitURL:   "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
-			VersionParts: &ServerVersionParts{
-				Major: 16,
-				Minor: 6,
-				Patch: 0,
-			},
+			Version:      "16.6.0",
+			BuildNumber:  "3348",
+			GitSha:       "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+			FullVersion:  "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+			CommitURL:    "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0",
+			VersionParts: ver,
 		}, v)
 
 		// Verify that the server version is cached
@@ -63,18 +63,16 @@ func testBadServerVersionMajor(t *testing.T, i int, errString string) {
 }
 
 func testServerVersionCaching(t *testing.T) {
+	ver, err := version.NewVersion("18.7.0")
+	assert.NoError(t, err)
 
 	cachedServerVersion = &ServerVersion{
-		Version:     "18.7.0",
-		BuildNumber: "7121",
-		GitSha:      "75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		FullVersion: "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
-		CommitURL:   "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		VersionParts: &ServerVersionParts{
-			Major: 18,
-			Minor: 7,
-			Patch: 0,
-		},
+		Version:      "18.7.0",
+		BuildNumber:  "7121",
+		GitSha:       "75d1247f58ab8bcde3c5b43392a87347979f82c5",
+		FullVersion:  "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
+		CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
+		VersionParts: ver,
 	}
 	v, b, err := client.ServerVersion.Get(context.Background())
 
@@ -82,15 +80,11 @@ func testServerVersionCaching(t *testing.T) {
 	assert.Nil(t, b)
 
 	assert.Equal(t, &ServerVersion{
-		Version:     "18.7.0",
-		BuildNumber: "7121",
-		GitSha:      "75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		FullVersion: "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
-		CommitURL:   "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
-		VersionParts: &ServerVersionParts{
-			Major: 18,
-			Minor: 7,
-			Patch: 0,
-		},
+		Version:      "18.7.0",
+		BuildNumber:  "7121",
+		GitSha:       "75d1247f58ab8bcde3c5b43392a87347979f82c5",
+		FullVersion:  "18.7.0 (7121-75d1247f58ab8bcde3c5b43392a87347979f82c5)",
+		CommitURL:    "https://github.com/gocd/gocd/commits/75d1247f58ab8bcde3c5b43392a87347979f82c5",
+		VersionParts: ver,
 	}, v)
 }


### PR DESCRIPTION
Added a resource struct to allow the server versions to be compared

## Description
Added a parser for the server version, so that it can be broken into a state where the versions can be compared meaningfully.

## Related Issue
Will simplify the work for #139 , #138 , and #137. @aerostitch this may be of use to you too.

## How Has This Been Tested?
Added test cases.

