### PR TITLE
Upgrade dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,48 +1,50 @@
-hash: f9aef73f0ceff479d04494095499bdb15e1d3b86e22a587320f404062010fb3b
-updated: 2017-12-29T10:29:23.608951455Z
+hash: 5466a335e10ab8259137b683cf79aefc921aaa45e45dba653036f22edd5a0aba
+updated: 2018-07-26T07:11:11.744908+01:00
 imports:
+- name: github.com/hashicorp/go-version
+  version: 270f2f71b1ee587f3b609f00f422b76a6b28f348
 - name: github.com/mattn/go-colorable
-  version: 586e6dcca296d085100876beb6dbf02287a247f7
+  version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
   version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/mgutz/ansi
   version: 9520e82c474b0a04dd04f8a40959027271bab992
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: c108f5553c369120b773da633aca62a8b42b1cf4
 - name: github.com/urakozz/go-json-schema-generator
   version: 645b0ded705ed7cec8c301e3bf11df8a4e544551
 - name: github.com/urfave/cli
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: golang.org/x/crypto
-  version: 95a4943f35d008beabde8c11e5075a1b714e6419
+  version: c126467f60eb25f8f27e5a981f32a87e3965053f
   subpackages:
   - ssh/terminal
 - name: golang.org/x/sys
-  version: 83801418e1b59fb1880e363299581ee543af32ca
+  version: e072cadbbdc8dd3d3ffa82b8b4b9304c261d9311
   subpackages:
   - unix
   - windows
 - name: gopkg.in/AlecAivazis/survey.v1
-  version: 0aa8b6a162b391fe2d95648b7677d1d6ac2090a6
+  version: 17861e192dc11fd2f5081df1932c94cce262fa1e
   subpackages:
   - core
   - terminal
 - name: gopkg.in/yaml.v2
-  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/goreleaser/goreleaser
-  version: 9068d941d0f7315328973393bd21d659f8edb1b4
+  version: 9154294c00a9e317198967c0c2f08cd9f04645c1
   subpackages:
   - assert
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,7 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/sirupsen/logrus
   version: master
+- package: github.com/hashicorp/go-version
 testImport:
 - package: github.com/goreleaser/goreleaser
   version: ^0.30.0


### PR DESCRIPTION
Added the hashicorp version library in anticipation of #142 

## How Has This Been Tested?
The dependencies have been updated with glide, but there has been no change in business logic, so the regression tests should handle any issues.
