### PR TITLE
Centralise integration testing client initialisation

### DIFF
--- a/gocd/gocd_test.go
+++ b/gocd/gocd_test.go
@@ -60,6 +60,7 @@ func setup() {
 		Password: "mockPassword",
 	}, nil)
 }
+
 func intSetup() {
 	intClient = NewClient(&Configuration{
 		Server: "http://127.0.0.1:8153/go/",
@@ -249,4 +250,10 @@ func testClientDo(t *testing.T) {
 
 	want := &foo{"a"}
 	assert.Equal(t, want, body)
+}
+
+func init() {
+	if runIntegrationTest() {
+		intSetup()
+	}
 }

--- a/gocd/role_gocd_test.go
+++ b/gocd/role_gocd_test.go
@@ -13,8 +13,6 @@ func TestRole(t *testing.T) {
 
 func testRoleGoCD(t *testing.T) {
 
-	intSetup()
-
 	if runIntegrationTest() {
 
 		ctx := context.Background()


### PR DESCRIPTION
Centralise the initialisation of the integration testing client

## Description
We don't need to re-initialise the integration testing client on every call, we can do this just once.

## How Has This Been Tested?
This is depended upon by test cases, so the test cases will only pass, if the client is correctly initialised.
