### PR TITLE
Switch to using integration tests for the pipeline configs

### DIFF
--- a/gocd/gocd_test.go
+++ b/gocd/gocd_test.go
@@ -72,7 +72,15 @@ func teardown() {
 	server.Close()
 }
 
-func runIntegrationTest() bool {
+func runIntegrationTest(t *testing.T) bool {
+	run := isIntegrationTest()
+	if !run {
+		skipIntegrationtest(t)
+	}
+	return run
+}
+
+func isIntegrationTest() bool {
 	return os.Getenv("GOCD_ACC") == "1"
 }
 
@@ -253,7 +261,7 @@ func testClientDo(t *testing.T) {
 }
 
 func init() {
-	if runIntegrationTest() {
+	if isIntegrationTest() {
 		intSetup()
 	}
 }

--- a/gocd/pipelineconfig.go
+++ b/gocd/pipelineconfig.go
@@ -39,6 +39,8 @@ func (pcs *PipelineConfigsService) Update(ctx context.Context, name string, p *P
 		ResponseBody: pr,
 	})
 
+	pr.Group = p.Group
+
 	return
 }
 
@@ -55,6 +57,8 @@ func (pcs *PipelineConfigsService) Create(ctx context.Context, group string, p *
 		},
 		ResponseBody: pr,
 	})
+
+	pr.Group = group
 
 	return
 }

--- a/gocd/pipelineconfig_test.go
+++ b/gocd/pipelineconfig_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPipelineConfig(t *testing.T) {
-	if runIntegrationTest() {
+	if runIntegrationTest(t) {
 		input := &Pipeline{
 			Name: "new_pipeline",
 			Materials: []Material{{

--- a/gocd/pipelineconfig_test.go
+++ b/gocd/pipelineconfig_test.go
@@ -2,181 +2,185 @@ package gocd
 
 import (
 	"context"
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"net/http"
+	"regexp"
 	"testing"
 )
 
 func TestPipelineConfig(t *testing.T) {
-	setup()
-	defer teardown()
-	t.Run("Create", testPipelineConfigCreate)
-	t.Run("Update", testPipelineConfigUpdate)
-	t.Run("Delete", testPipelineConfigDelete)
-	t.Run("Get", testPipelineConfigGet)
-}
+	if runIntegrationTest() {
+		input := &Pipeline{
+			Name: "new_pipeline",
+			Materials: []Material{{
+				Type: "git",
+				Attributes: MaterialAttributesGit{
+					URL:         "git@github.com:sample_repo/example.git",
+					Destination: "dest",
+					Branch:      "master",
+				},
+			}},
+			Stages: []*Stage{{
+				Name: "defaultStage",
+				Jobs: []*Job{{
+					Name: "defaultJob",
+					Tasks: []*Task{{
+						Type: "exec",
+						Attributes: TaskAttributes{
+							RunIf:   []string{"passed"},
+							Command: "ls",
+						},
+					}},
+				}},
+			}},
+		}
 
-func testPipelineConfigGet(t *testing.T) {
-	mux.HandleFunc("/api/admin/pipelines/test-pipeline0", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v4+json")
+		ctx := context.Background()
 
-		j, _ := ioutil.ReadFile("test/resources/pipelineconfig.0.json")
-		w.Header().Set("Etag", "mock-etag")
-		fmt.Fprint(w, string(j))
-	})
+		p, _, err := intClient.PipelineConfigs.Create(ctx, "test-group", input)
+		assert.NoError(t, err)
+		assert.Regexp(t, regexp.MustCompile("^[a-f0-9]{32}--gzip$"), p.Version)
 
-	pc, _, err := client.PipelineConfigs.Get(context.Background(), "test-pipeline0")
-	if err != nil {
-		t.Error(err)
+		p.RemoveLinks()
+		assert.Equal(t, &Pipeline{
+			Group:                "test-group",
+			Name:                 "new_pipeline",
+			LabelTemplate:        "${COUNT}",
+			Parameters:           make([]*Parameter, 0),
+			EnvironmentVariables: make([]*EnvironmentVariable, 0),
+			Materials: []Material{{
+				Type: "git",
+				Attributes: &MaterialAttributesGit{
+					URL:         "git@github.com:sample_repo/example.git",
+					Destination: "dest",
+					Branch:      "master",
+					AutoUpdate:  true,
+				},
+			}},
+			Stages: []*Stage{{
+				Name: "defaultStage",
+				Approval: &Approval{
+					Type: "success",
+					Authorization: &Authorization{
+						Users: []string{},
+						Roles: []string{},
+					},
+				},
+				Jobs: []*Job{{
+					Name:                 "defaultJob",
+					EnvironmentVariables: []*EnvironmentVariable{},
+					Resources:            []string{},
+					Tasks: []*Task{{
+						Type: "exec",
+						Attributes: TaskAttributes{
+							RunIf:   []string{"passed"},
+							Command: "ls",
+						},
+					}},
+					Tabs:      []*Tab{},
+					Artifacts: []*Artifact{},
+				}},
+				EnvironmentVariables: []*EnvironmentVariable{},
+			}},
+			Version: p.Version,
+		}, p)
+
+		getP, _, err := intClient.PipelineConfigs.Get(ctx, input.Name)
+
+		getP.RemoveLinks()
+		assert.Equal(t, &Pipeline{
+			Name:                 "new_pipeline",
+			LabelTemplate:        "${COUNT}",
+			Parameters:           make([]*Parameter, 0),
+			EnvironmentVariables: make([]*EnvironmentVariable, 0),
+			Materials: []Material{{
+				Type: "git",
+				Attributes: &MaterialAttributesGit{
+					URL:         "git@github.com:sample_repo/example.git",
+					Destination: "dest",
+					Branch:      "master",
+					AutoUpdate:  true,
+				},
+			}},
+			Stages: []*Stage{{
+				Name: "defaultStage",
+				Approval: &Approval{
+					Type: "success",
+					Authorization: &Authorization{
+						Users: []string{},
+						Roles: []string{},
+					},
+				},
+				Jobs: []*Job{{
+					Name:                 "defaultJob",
+					EnvironmentVariables: []*EnvironmentVariable{},
+					Resources:            []string{},
+					Tasks: []*Task{{
+						Type: "exec",
+						Attributes: TaskAttributes{
+							RunIf:   []string{"passed"},
+							Command: "ls",
+						},
+					}},
+					Tabs:      []*Tab{},
+					Artifacts: []*Artifact{},
+				}},
+				EnvironmentVariables: []*EnvironmentVariable{},
+			}},
+			Version: p.Version,
+		}, getP)
+
+		p.LabelTemplate = "Updated_${COUNT}"
+		updatedP, _, err := intClient.PipelineConfigs.Update(context.Background(), p.Name, p)
+		assert.NoError(t, err)
+		assert.NotEqual(t, p.Version, updatedP.Version)
+		updatedP.Version = p.Version
+
+		updatedP.RemoveLinks()
+		assert.Equal(t, &Pipeline{
+			Group:                "test-group",
+			Name:                 "new_pipeline",
+			LabelTemplate:        p.LabelTemplate,
+			Parameters:           make([]*Parameter, 0),
+			EnvironmentVariables: make([]*EnvironmentVariable, 0),
+			Materials: []Material{{
+				Type: "git",
+				Attributes: &MaterialAttributesGit{
+					URL:         "git@github.com:sample_repo/example.git",
+					Destination: "dest",
+					Branch:      "master",
+					AutoUpdate:  true,
+				},
+			}},
+			Stages: []*Stage{{
+				Name: "defaultStage",
+				Approval: &Approval{
+					Type: "success",
+					Authorization: &Authorization{
+						Users: []string{},
+						Roles: []string{},
+					},
+				},
+				Jobs: []*Job{{
+					Name:                 "defaultJob",
+					EnvironmentVariables: []*EnvironmentVariable{},
+					Resources:            []string{},
+					Tasks: []*Task{{
+						Type: "exec",
+						Attributes: TaskAttributes{
+							RunIf:   []string{"passed"},
+							Command: "ls",
+						},
+					}},
+					Tabs:      []*Tab{},
+					Artifacts: []*Artifact{},
+				}},
+				EnvironmentVariables: []*EnvironmentVariable{},
+			}},
+			Version: p.Version,
+		}, updatedP)
+
+		message, _, err := intClient.PipelineConfigs.Delete(ctx, input.Name)
+		assert.Equal(t, "The pipeline 'new_pipeline' was deleted successfully.", message)
+
 	}
-
-	assert.NotNil(t, pc)
-	assert.Equal(t, "mock-etag", pc.Version)
-
-	assert.NotNil(t, pc.Links.Get("Self"))
-	assert.Equal(t, "https://ci.example.com/go/api/admin/pipelines/new_pipeline", pc.Links.Get("Self").URL.String())
-	assert.NotNil(t, pc.Links.Get("Doc"))
-	assert.Equal(t, "https://api.gocd.org/#pipeline-config", pc.Links.Get("Doc").URL.String())
-	assert.NotNil(t, pc.Links.Get("Find"))
-	assert.Equal(t, "https://ci.example.com/go/api/admin/pipelines/:name", pc.Links.Get("Find").URL.String())
-
-	assert.Equal(t, "${COUNT}", pc.LabelTemplate)
-	assert.True(t, pc.EnablePipelineLocking)
-	assert.Equal(t, "new_pipeline", pc.Name)
-	assert.Empty(t, pc.Template)
-
-	assert.NotNil(t, pc.Origin)
-	assert.Equal(t, "local", pc.Origin.Type)
-	assert.Equal(t, "cruise-config.xml", pc.Origin.File)
-
-	assert.Len(t, pc.Parameters, 0)
-	assert.Len(t, pc.EnvironmentVariables, 0)
-
-	assert.NotNil(t, pc.Materials)
-	assert.Len(t, pc.Materials, 1)
-	m := pc.Materials[0]
-
-	a := m.Attributes.(*MaterialAttributesGit)
-	assert.Equal(t, "git", m.Type)
-	assert.NotNil(t, a)
-	assert.Equal(t, "git@github.com:sample_repo/example.git", a.URL)
-	assert.Equal(t, "dest", a.Destination)
-	assert.Nil(t, a.Filter)
-	assert.False(t, a.InvertFilter)
-	assert.Empty(t, a.Name)
-	assert.True(t, a.AutoUpdate)
-	assert.Equal(t, "master", a.Branch)
-	assert.Empty(t, a.SubmoduleFolder)
-	assert.True(t, a.ShallowClone)
-
-	assert.NotNil(t, pc.Stages)
-	assert.Len(t, pc.Stages, 1)
-
-	s := pc.Stages[0]
-	assert.Equal(t, "defaultStage", s.Name)
-	assert.True(t, s.FetchMaterials)
-	assert.False(t, s.CleanWorkingDirectory)
-	assert.False(t, s.NeverCleanupArtifacts)
-	assert.NotNil(t, s.Approval)
-	assert.Equal(t, "success", s.Approval.Type)
-	assert.NotNil(t, s.Approval.Authorization)
-	assert.Len(t, s.Approval.Authorization.Roles, 0)
-	assert.Len(t, s.Approval.Authorization.Users, 0)
-	assert.Len(t, s.EnvironmentVariables, 0)
-
-	assert.NotNil(t, s.Jobs)
-	assert.Len(t, s.Jobs, 1)
-
-	j := s.Jobs[0]
-	assert.Equal(t, "defaultJob", j.Name)
-	assert.Empty(t, j.RunInstanceCount)
-	assert.Equal(t, TimeoutField(0), j.Timeout)
-	assert.Len(t, j.EnvironmentVariables, 0)
-	assert.Len(t, j.Resources, 0)
-
-	assert.NotNil(t, j.Tasks)
-	assert.Len(t, j.Tasks, 1)
-
-	tsk := j.Tasks[0]
-	assert.Equal(t, "exec", tsk.Type)
-	assert.NotNil(t, tsk.Attributes)
-	assert.Len(t, tsk.Attributes.RunIf, 1)
-	assert.Equal(t, "passed", tsk.Attributes.RunIf[0])
-	assert.Equal(t, "ls", tsk.Attributes.Command)
-	assert.Empty(t, tsk.Attributes.WorkingDirectory)
-
-	assert.Len(t, j.Tabs, 0)
-	assert.Len(t, j.Artifacts, 0)
-	assert.Nil(t, j.Properties)
-
-	// @TODO implement timer and trackingtool
-	//assert.Empty(t, pc.TrackingTool)
-	//assert.Empty(t, pc.Timer)
-}
-
-func testPipelineConfigDelete(t *testing.T) {
-
-	mux.HandleFunc("/api/admin/pipelines/test-pipeline", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "DELETE", "Unexpected HTTP method")
-		assert.Equal(t, r.Header.Get("Accept"), apiV4)
-
-		fmt.Fprint(w, `{
-  "message": "Pipeline 'test-pipeline' was deleted successfully."
-}`)
-	})
-	message, resp, err := client.PipelineConfigs.Delete(context.Background(), "test-pipeline")
-	if err != nil {
-		assert.Error(t, err)
-	}
-	assert.NotNil(t, resp)
-	assert.Equal(t, "Pipeline 'test-pipeline' was deleted successfully.", message)
-}
-
-func testPipelineConfigCreate(t *testing.T) {
-	mux.HandleFunc("/api/admin/pipelines", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-		//b, err := ioutil.ReadAll(r.Body)
-		//if err != nil {
-		//	t.Error(err)
-		//}
-		//assert.Equal(
-		//	t,
-		//	"{\n  \"group\": \"test-group\",\n  \"pipeline\": {\n    \"name\": \"\",\n    \"stages\": null\n  }\n}\n",
-		//	string(b))
-		j, _ := ioutil.ReadFile("test/resources/pipelineconfig.0.json")
-		fmt.Fprint(w, string(j))
-	})
-
-	p := Pipeline{}
-	pgs, _, err := client.PipelineConfigs.Create(context.Background(), "test-group", &p)
-	if err != nil {
-		t.Error(t, err)
-	}
-
-	assert.NotNil(t, pgs)
-}
-
-func testPipelineConfigUpdate(t *testing.T) {
-	mux.HandleFunc("/api/admin/pipelines/test-name", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "PUT", r.Method, "Unexpected HTTP method")
-
-		j, _ := ioutil.ReadFile("test/resources/pipelineconfig.0.json")
-
-		assert.Equal(t, `"test-version"`, r.Header.Get("If-Match"))
-		w.Header().Set("ETag", `"mock-version"`)
-		fmt.Fprint(w, string(j))
-	})
-
-	p := Pipeline{Version: "test-version"}
-	pcs, _, err := client.PipelineConfigs.Update(context.Background(), "test-name", &p)
-	if err != nil {
-		t.Error(t, err)
-	}
-
-	assert.Equal(t, pcs.Version, "mock-version")
-
-	assert.NotNil(t, pcs)
 }

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -19,7 +19,6 @@ func init() {
 				newServerAPI("17.4.0", apiV4)),
 		},
 	}
-	fmt.Print(serverVersionLookup)
 }
 
 // GetAPIVersion for a given endpoint and method

--- a/gocd/role_gocd_test.go
+++ b/gocd/role_gocd_test.go
@@ -13,7 +13,7 @@ func TestRole(t *testing.T) {
 
 func testRoleGoCD(t *testing.T) {
 
-	if runIntegrationTest() {
+	if runIntegrationTest(t) {
 
 		ctx := context.Background()
 

--- a/gocd/server_version_test.go
+++ b/gocd/server_version_test.go
@@ -51,7 +51,7 @@ func testServerVersion(t *testing.T) {
 }
 
 func testServerVersionCaching(t *testing.T) {
-	if runIntegrationTest() {
+	if runIntegrationTest(t) {
 		ver, err := version.NewVersion("18.7.0")
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Use integration tests, not mocks

## Description
Removed the mocked endpoints from the pipeline config test cases and used the integration test framework

## Related Issue
Handling different versions is a lot easier if the tests hit a real endpoint instead of a mock. This is related to #137, #138, #139 .

## How Has This Been Tested?
These are test cases.
