### PR TITLE
Bump GoCD Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 env:
  - GOCD_VERSION=v17.10.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
- - GOCD_VERSION=v18.6.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
+ - GOCD_VERSION=v18.7.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
 
 addons:
   apt:
@@ -19,7 +19,7 @@ addons:
 matrix:
   fast_finish: true
   allow_failures:
-   - env: GOCD_VERSION=v18.6.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
+   - env: GOCD_VERSION=v18.7.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
 
 before_install:
   - make before_install


### PR DESCRIPTION
Rather than create a brand new env for each GoCD release, only create releases for versions with breaking changes to the API.

## Description
Updated GoCD to latest changes. 18.7.0 introduces breaking changes to the API, and 18.6.0 did not, so we bump the existing version.

## Related Issue
 This will test the changes in:
 - #139 
 - #138 
- #137 

## Motivation and Context
As there are breaking changes being introduced in GoCD releases, we should make sure our test cases provide coverage and correct functionality for each breaking change/GoCD release.

## How Has This Been Tested?
This is the testing context, so it's testing code, not testable itself.
