### PR TITLE
Add apiV0 for unversionned API

### DIFF
--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -24,6 +24,8 @@ const (
 	libraryVersion = "1"
 	// UserAgent to be used when calling the GoCD agent.
 	userAgent = "go-gocd/" + libraryVersion
+	// For the unversionned API
+	apiV0 = ""
 	// Version 1 of the GoCD API.
 	apiV1 = "application/vnd.go.cd.v1+json"
 	// Version 2 of the GoCD API.


### PR DESCRIPTION
## Description

In order to keep things uniform in the server version lookup I propose to add a `apiV0` const which will be an empty string and use it for unversioned API.

## Motivation and Context

The rationale behind is to be able to differentiate the case when the API is unversioned from the case when the API is not yet supported in GoCD.

Example:
The `/api/version` was not available before version `16.6.0` and has been directly introduced using an apiV1. Trying to query that endpoint with an unversioned API will fail.

But if you look at the `/go/api/pipelines/:pipeline_name/pause`, it has been supported as an unversioned API since `14.3.0` and an apiV1 since `18.2.0`.

Does that makes sense?