### PR TITLE
Make sure GoCD 18.7.0 testcases pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
 
 matrix:
   fast_finish: true
-  allow_failures:
-   - env: GOCD_VERSION=v18.7.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
 
 before_install:
   - make before_install


### PR DESCRIPTION
Enforce the validation fo GoCD 18.7.0

## Description
All test cases are currently passing.
The intention is over time, to migrate the test cases from mocking endpoints to integration tests and hitting a real gocd endpoint (in docker).
Integration tests should pass, and mocks should pass, so there’s no reason to allow failures on 18.7.0

## Motivation and Context
There will be a gradual push towards using integration tests for the GoCD api, rather than mocks to ensure the library works with all supported versions of GoCD.

## How Has This Been Tested?
The test cases pass on travis. There will be some mocks which are not reflecting changes in the API, but these will be discovered over time, and addressed through the test cases migration.