### PR TITLE
Use integration testcases for pipeline actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
 
 matrix:
   fast_finish: true
-  allow_failures:
-   - env: GOCD_VERSION=v18.7.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
 
 before_install:
   - make before_install

--- a/gocd/genericactions.go
+++ b/gocd/genericactions.go
@@ -73,12 +73,12 @@ func (c *Client) deleteAction(ctx context.Context, path string, apiversion strin
 func (c *Client) httpAction(ctx context.Context, r *APIClientRequest) (responseBody interface{}, resp *APIResponse, err error) {
 
 	var req *APIRequest
-	var requestBodyProvided, hasHeaders, hasResponseType, hasJSONResponseType bool
+	var requestBodyProvided, hasHeaders, hasEmptyResponseType, hasJSONResponseType bool
 
-	requestBodyProvided = r.ResponseBody != nil
+	requestBodyProvided = r.RequestBody != nil
 	hasHeaders = len(r.Headers) > 0
-	hasResponseType = r.ResponseType != ""
-	if hasResponseType {
+	hasEmptyResponseType = r.ResponseType == ""
+	if !hasEmptyResponseType {
 		hasJSONResponseType = r.ResponseType == responseTypeJSON
 	}
 
@@ -87,7 +87,7 @@ func (c *Client) httpAction(ctx context.Context, r *APIClientRequest) (responseB
 		"Path":   r.Path,
 	}).Debug("Requesting Endpoint")
 
-	if !hasResponseType {
+	if hasEmptyResponseType {
 		r.ResponseType = responseTypeJSON
 	}
 

--- a/gocd/genericactions.go
+++ b/gocd/genericactions.go
@@ -73,10 +73,9 @@ func (c *Client) deleteAction(ctx context.Context, path string, apiversion strin
 func (c *Client) httpAction(ctx context.Context, r *APIClientRequest) (responseBody interface{}, resp *APIResponse, err error) {
 
 	var req *APIRequest
-	var requestBodyProvided, hasHeaders, hasEmptyResponseType, hasJSONResponseType bool
+	var requestBodyProvided, hasEmptyResponseType, hasJSONResponseType bool
 
 	requestBodyProvided = r.RequestBody != nil
-	hasHeaders = len(r.Headers) > 0
 	hasEmptyResponseType = r.ResponseType == ""
 	if !hasEmptyResponseType {
 		hasJSONResponseType = r.ResponseType == responseTypeJSON
@@ -92,7 +91,7 @@ func (c *Client) httpAction(ctx context.Context, r *APIClientRequest) (responseB
 	}
 
 	versionAction(r.RequestBody, func(ver Versioned) {
-		if !hasHeaders {
+		if r.Headers == nil {
 			r.Headers = map[string]string{}
 		}
 		r.Headers["If-Match"] = fmt.Sprintf(`"%s"`, ver.GetVersion())
@@ -106,7 +105,7 @@ func (c *Client) httpAction(ctx context.Context, r *APIClientRequest) (responseB
 		c.Log.WithField("RequestBody", req.Body).Debug("Sending Request Body")
 	}
 
-	if hasHeaders {
+	if len(r.Headers) > 0 {
 		for key, value := range r.Headers {
 			req.HTTP.Header.Set(key, value)
 		}

--- a/gocd/genericactions.go
+++ b/gocd/genericactions.go
@@ -94,7 +94,7 @@ func (c *Client) httpAction(ctx context.Context, r *APIClientRequest) (responseB
 		return false, nil, err
 	}
 	if r.RequestBody != nil {
-		c.Log.WithField("RequestBody", r.RequestBody).Debug("Sending Request Body")
+		c.Log.WithField("RequestBody", req.Body).Debug("Sending Request Body")
 	}
 
 	if len(r.Headers) > 0 {

--- a/gocd/gocd_test.go
+++ b/gocd/gocd_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	mockAuthorization = "Basic bW9ja1VzZXJuYW1lOm1vY2tQYXNzd29yZA=="
-	mockTestingGroup = "gocd-unittests"
+	mockTestingGroup  = "gocd-unittests"
 )
 
 type mockReadCloserFail struct {

--- a/gocd/gocd_test.go
+++ b/gocd/gocd_test.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	mockAuthorization = "Basic bW9ja1VzZXJuYW1lOm1vY2tQYXNzd29yZA=="
+	mockTestingGroup = "gocd-unittests"
 )
 
 type mockReadCloserFail struct {

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -170,6 +170,7 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 		return false, nil, err
 	}
 
+	responseBody := map[string]interface{}{}
 	request := &APIClientRequest{
 		Path:       fmt.Sprintf("pipelines/%s/%s", name, action),
 		APIVersion: apiVersion,
@@ -179,6 +180,7 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 		request.Headers = map[string]string{"Confirm": "true"}
 	} else {
 		request.ResponseType = responseTypeJSON
+		request.ResponseBody = &responseBody
 	}
 
 	_, resp, err := pgs.client.postAction(ctx, request)

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -170,16 +170,18 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 		return false, nil, err
 	}
 
-	headers := map[string]string{"X-GoCD-Confirm": "true"}
-	if apiVersion == apiV0 {
-		headers = map[string]string{"Confirm": "true"}
-	}
-
-	_, resp, err := pgs.client.postAction(ctx, &APIClientRequest{
+	request := &APIClientRequest{
 		Path:       fmt.Sprintf("pipelines/%s/%s", name, action),
 		APIVersion: apiVersion,
-		Headers:    headers,
-	})
+	}
+	request.Headers = map[string]string{"X-GoCD-Confirm": "true"}
+	if apiVersion == apiV0 {
+		request.Headers = map[string]string{"Confirm": "true"}
+	} else {
+		request.ResponseType = responseTypeJSON
+	}
+
+	_, resp, err := pgs.client.postAction(ctx, request)
 
 	return resp.HTTP.StatusCode == 200, resp, err
 }

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -174,13 +174,7 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 		Path:       fmt.Sprintf("pipelines/%s/%s", name, action),
 		APIVersion: apiVersion,
 	}
-	request.Headers = map[string]string{"X-GoCD-Confirm": "true"}
-	if apiVersion == apiV0 {
-		request.Headers = map[string]string{"Confirm": "true"}
-	} else {
-		request.ResponseType = responseTypeJSON
-		request.ResponseBody = &map[string]interface{}{}
-	}
+	choosePipelineConfirmHeader(request, apiVersion)
 
 	_, resp, err := pgs.client.postAction(ctx, request)
 
@@ -193,4 +187,15 @@ func (pgs *PipelinesService) buildPaginatedStub(format string, name string, offs
 		stub = fmt.Sprintf("%s/%d", stub, offset)
 	}
 	return
+}
+
+func choosePipelineConfirmHeader(request *APIClientRequest, apiVersion string) {
+	request.Headers = map[string]string{"X-GoCD-Confirm": "true"}
+	if apiVersion == apiV0 {
+		request.Headers = map[string]string{"Confirm": "true"}
+	} else {
+		request.ResponseType = responseTypeJSON
+		request.ResponseBody = &map[string]interface{}{}
+	}
+
 }

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -170,7 +170,6 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 		return false, nil, err
 	}
 
-	responseBody := map[string]interface{}{}
 	request := &APIClientRequest{
 		Path:       fmt.Sprintf("pipelines/%s/%s", name, action),
 		APIVersion: apiVersion,
@@ -180,7 +179,7 @@ func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, ac
 		request.Headers = map[string]string{"Confirm": "true"}
 	} else {
 		request.ResponseType = responseTypeJSON
-		request.ResponseBody = &responseBody
+		request.ResponseBody = &map[string]interface{}{}
 	}
 
 	_, resp, err := pgs.client.postAction(ctx, request)

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -10,41 +10,48 @@ import (
 
 func testPipelineServicePause(t *testing.T) {
 	for n, test := range []struct {
+		name          string
 		v             *ServerVersion
 		confirmHeader string
 		acceptHeader  string
 	}{
 		{
+			name:          "server-version-14.3.0",
 			v:             &ServerVersion{Version: "14.3.0"},
 			confirmHeader: "Confirm",
 			acceptHeader:  apiV0,
 		},
 		{
+			name:          "server-version-18.3.0",
 			v:             &ServerVersion{Version: "18.3.0"},
 			confirmHeader: "X-GoCD-Confirm",
 			acceptHeader:  apiV1,
 		},
 	} {
-		err := test.v.parseVersion()
-		assert.NoError(t, err)
+		t.Run(test.name, func(t *testing.T) {
+			if runIntegrationTest(t) {
 
-		cachedServerVersion = test.v
-		// defaultHTTPMux doesn't support multiple registrations so change the url a bit
-		mux.HandleFunc(fmt.Sprintf("/api/pipelines/test-pipeline%d/pause", n), func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-			assert.Equal(t, "true", r.Header.Get(test.confirmHeader))
-			if test.acceptHeader == "" {
-				assert.Equal(t, len(r.Header["Accept"]), 0)
-			} else {
-				assert.Contains(t, r.Header["Accept"], test.acceptHeader)
+				pipelineName := fmt.Sprintf("test-pipeline-un-pause%d", n)
+
+				err := test.v.parseVersion()
+				assert.NoError(t, err)
+
+				cachedServerVersion = test.v
+
+				ctx := context.Background()
+
+				pausePipeline, _, err := intClient.PipelineConfigs.Create(ctx, mockTestingGroup, &Pipeline{
+					Name: pipelineName,
+				})
+
+				pp, _, err := intClient.Pipelines.Pause(context.Background(), pausePipeline.Name)
+				assert.NoError(t, err)
+				assert.True(t, pp)
+
+				deleteResponse, _, err := intClient.PipelineConfigs.Delete(ctx, pausePipeline.Name)
+				assert.Equal(t, "", deleteResponse)
 			}
-			fmt.Fprint(w, "")
 		})
-		pp, _, err := client.Pipelines.Pause(context.Background(), fmt.Sprintf("test-pipeline%d", n))
-		if err != nil {
-			assert.Nil(t, err)
-		}
-		assert.True(t, pp)
 	}
 }
 

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -2,140 +2,55 @@ package gocd
 
 import (
 	"context"
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	"net/http"
 	"testing"
 )
 
-func testPipelineServicePause(t *testing.T) {
-	for n, test := range []struct {
-		name          string
-		v             *ServerVersion
-		confirmHeader string
-		acceptHeader  string
-	}{
-		{
-			name:          "server-version-14.3.0",
-			v:             &ServerVersion{Version: "14.3.0"},
-			confirmHeader: "Confirm",
-			acceptHeader:  apiV0,
-		},
-		{
-			name:          "server-version-18.3.0",
-			v:             &ServerVersion{Version: "18.3.0"},
-			confirmHeader: "X-GoCD-Confirm",
-			acceptHeader:  apiV1,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if runIntegrationTest(t) {
+func testPipelineServiceUnPause(t *testing.T) {
+	if runIntegrationTest(t) {
 
-				ctx := context.Background()
-				pipelineName := fmt.Sprintf("test-pipeline-un-pause%d", n)
+		ctx := context.Background()
+		pipelineName := "test-pipeline-un-pause"
 
-				err := test.v.parseVersion()
-				assert.NoError(t, err)
-
-				cachedServerVersion = test.v
-
-				pausePipeline, _, err := intClient.PipelineConfigs.Create(ctx, mockTestingGroup, &Pipeline{
-					Name: pipelineName,
-					Materials: []Material{{
-						Type: "git",
-					}},
-					Stages: buildMockPipelineStages(),
-				})
-				assert.NoError(t, err)
-				assert.Equal(t, nil, pausePipeline)
-
-				pp, _, err := intClient.Pipelines.Pause(ctx, pipelineName)
-				assert.NoError(t, err)
-				assert.True(t, pp)
-
-				deleteResponse, _, err := intClient.PipelineConfigs.Delete(ctx, pipelineName)
-				assert.Equal(t, "", deleteResponse)
-			}
-		})
-	}
-}
-
-func testPipelineServiceUnpause(t *testing.T) {
-	for n, test := range []struct {
-		v             *ServerVersion
-		confirmHeader string
-		acceptHeader  string
-	}{
-		{
-			v:             &ServerVersion{Version: "14.3.0"},
-			confirmHeader: "Confirm",
-			acceptHeader:  apiV0,
-		},
-		{
-			v:             &ServerVersion{Version: "18.3.0"},
-			confirmHeader: "X-GoCD-Confirm",
-			acceptHeader:  apiV1,
-		},
-	} {
-		err := test.v.parseVersion()
-		assert.NoError(t, err)
-
-		cachedServerVersion = test.v
-		// defaultHTTPMux doesn't support multiple registrations so change the url a bit
-		mux.HandleFunc(fmt.Sprintf("/api/pipelines/test-pipeline%d/unpause", n), func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-			assert.Equal(t, "true", r.Header.Get(test.confirmHeader))
-			if test.acceptHeader == "" {
-				assert.Equal(t, len(r.Header["Accept"]), 0)
-			} else {
-				assert.Contains(t, r.Header["Accept"], test.acceptHeader)
-			}
-			fmt.Fprint(w, "")
-		})
-		pp, _, err := client.Pipelines.Unpause(context.Background(), fmt.Sprintf("test-pipeline%d", n))
-		if err != nil {
-			assert.Nil(t, err)
+		stages := buildMockPipelineStages()
+		mockPipeline := &Pipeline{
+			Name:                 pipelineName,
+			Group:                mockTestingGroup,
+			LabelTemplate:        "${COUNT}",
+			Parameters:           make([]*Parameter, 0),
+			EnvironmentVariables: make([]*EnvironmentVariable, 0),
+			Materials: []Material{{
+				Type: "git",
+				Attributes: &MaterialAttributesGit{
+					URL:         "git@github.com:sample_repo/example.git",
+					Destination: "dest",
+					Branch:      "master",
+					AutoUpdate:  true,
+				},
+			}},
+			Stages: stages,
 		}
-		assert.True(t, pp)
-	}
-}
 
-func testPipelineServiceReleaseLock(t *testing.T) {
-	for n, test := range []struct {
-		v             *ServerVersion
-		confirmHeader string
-		acceptHeader  string
-	}{
-		{
-			v:             &ServerVersion{Version: "14.3.0"},
-			confirmHeader: "Confirm",
-			acceptHeader:  apiV0,
-		},
-		{
-			v:             &ServerVersion{Version: "18.3.0"},
-			confirmHeader: "X-GoCD-Confirm",
-			acceptHeader:  apiV1,
-		},
-	} {
-		err := test.v.parseVersion()
+		pausePipeline, _, err := intClient.PipelineConfigs.Create(ctx, mockTestingGroup, mockPipeline)
 		assert.NoError(t, err)
+		pausePipeline.Links = nil
+		pausePipeline.Version = ""
+		assert.Equal(t, mockPipeline, pausePipeline)
 
-		cachedServerVersion = test.v
-		// defaultHTTPMux doesn't support multiple registrations so change the url a bit
-		mux.HandleFunc(fmt.Sprintf("/api/pipelines/test-pipeline%d/releaseLock", n), func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-			assert.Equal(t, "true", r.Header.Get(test.confirmHeader))
-			if test.acceptHeader == "" {
-				assert.Equal(t, len(r.Header["Accept"]), 0)
-			} else {
-				assert.Contains(t, r.Header["Accept"], test.acceptHeader)
-			}
-			fmt.Fprint(w, "")
-		})
-		pp, _, err := client.Pipelines.ReleaseLock(context.Background(), fmt.Sprintf("test-pipeline%d", n))
-		if err != nil {
-			assert.Nil(t, err)
-		}
+		pp, _, err := intClient.Pipelines.Unpause(ctx, pipelineName)
+		assert.NoError(t, err)
 		assert.True(t, pp)
+
+		pp, _, err = intClient.Pipelines.Pause(ctx, pipelineName)
+		assert.NoError(t, err)
+		assert.True(t, pp)
+
+		pp, _, err = intClient.Pipelines.ReleaseLock(context.Background(), pipelineName)
+		assert.EqualError(t, err, "Received HTTP Status '406 Not Acceptable'")
+		assert.False(t, pp)
+
+		deleteResponse, _, err := intClient.PipelineConfigs.Delete(ctx, pipelineName)
+		assert.Equal(t, "The pipeline 'test-pipeline-un-pause' was deleted successfully.", deleteResponse)
 	}
+
 }

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -41,13 +41,19 @@ func testPipelineServicePause(t *testing.T) {
 
 				pausePipeline, _, err := intClient.PipelineConfigs.Create(ctx, mockTestingGroup, &Pipeline{
 					Name: pipelineName,
+					Materials: []Material{{
+						Type: "git",
+					}},
+					Stages: buildMockPipelineStages(),
 				})
+				assert.NoError(t, err)
+				assert.Equal(t, nil, pausePipeline)
 
-				pp, _, err := intClient.Pipelines.Pause(ctx, pausePipeline.Name)
+				pp, _, err := intClient.Pipelines.Pause(ctx, pipelineName)
 				assert.NoError(t, err)
 				assert.True(t, pp)
 
-				deleteResponse, _, err := intClient.PipelineConfigs.Delete(ctx, pausePipeline.Name)
+				deleteResponse, _, err := intClient.PipelineConfigs.Delete(ctx, pipelineName)
 				assert.Equal(t, "", deleteResponse)
 			}
 		})

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -31,6 +31,7 @@ func testPipelineServicePause(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if runIntegrationTest(t) {
 
+				ctx := context.Background()
 				pipelineName := fmt.Sprintf("test-pipeline-un-pause%d", n)
 
 				err := test.v.parseVersion()
@@ -38,13 +39,11 @@ func testPipelineServicePause(t *testing.T) {
 
 				cachedServerVersion = test.v
 
-				ctx := context.Background()
-
 				pausePipeline, _, err := intClient.PipelineConfigs.Create(ctx, mockTestingGroup, &Pipeline{
 					Name: pipelineName,
 				})
 
-				pp, _, err := intClient.Pipelines.Pause(context.Background(), pausePipeline.Name)
+				pp, _, err := intClient.Pipelines.Pause(ctx, pausePipeline.Name)
 				assert.NoError(t, err)
 				assert.True(t, pp)
 

--- a/gocd/pipeline_test.go
+++ b/gocd/pipeline_test.go
@@ -18,9 +18,8 @@ func TestPipelineService(t *testing.T) {
 	t.Run("Create", testPipelineServiceCreate)
 	t.Run("GetHistory", testPipelineServiceGetHistory)
 	t.Run("GetStatus", testPipelineServiceGetStatus)
-	t.Run("Pause", testPipelineServicePause)
-	t.Run("Unpause", testPipelineServiceUnpause)
-	t.Run("ReleaseLock", testPipelineServiceReleaseLock)
+	t.Run("Un/Pause", testPipelineServiceUnPause)
+	//t.Run("ReleaseLock", testPipelineServiceReleaseLock)
 	t.Run("PaginationStub", testPipelineServicePaginationStub)
 	t.Run("StageContainer", testPipelineStageContainer)
 }

--- a/gocd/pipeline_test.go
+++ b/gocd/pipeline_test.go
@@ -22,6 +22,7 @@ func TestPipelineService(t *testing.T) {
 	//t.Run("ReleaseLock", testPipelineServiceReleaseLock)
 	t.Run("PaginationStub", testPipelineServicePaginationStub)
 	t.Run("StageContainer", testPipelineStageContainer)
+	t.Run("ConfirmHeader", testChoosePipelineConfirmHeader)
 }
 
 func testPipelineStageContainer(t *testing.T) {
@@ -210,4 +211,72 @@ func testPipelineServiceGetHistory(t *testing.T) {
 	h2s := h2.Stages[0]
 	assert.Equal(t, h2s.Name, "stage1")
 
+}
+
+func testChoosePipelineConfirmHeader(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		apiVersion       string
+		wantHeaders      map[string]string
+		wantResponseType string
+		wantResponseBody interface{}
+	}{
+		{
+			name:             "confirm",
+			apiVersion:       "",
+			wantHeaders:      map[string]string{"Confirm": "true"},
+			wantResponseType: "",
+			wantResponseBody: nil,
+		},
+		{
+			name:             "x-confirm-v1",
+			apiVersion:       "application/vnd.go.cd.v1+json",
+			wantHeaders:      map[string]string{"X-GoCD-Confirm": "true"},
+			wantResponseType: "json",
+			wantResponseBody: &map[string]interface{}{},
+		},
+		{
+			name:             "x-confirm-v2",
+			apiVersion:       "application/vnd.go.cd.v2+json",
+			wantHeaders:      map[string]string{"X-GoCD-Confirm": "true"},
+			wantResponseType: "json",
+			wantResponseBody: &map[string]interface{}{},
+		},
+		{
+			name:             "x-confirm-v3",
+			apiVersion:       "application/vnd.go.cd.v3+json",
+			wantHeaders:      map[string]string{"X-GoCD-Confirm": "true"},
+			wantResponseType: "json",
+			wantResponseBody: &map[string]interface{}{},
+		},
+		{
+			name:             "x-confirm-v4",
+			apiVersion:       "application/vnd.go.cd.v4+json",
+			wantHeaders:      map[string]string{"X-GoCD-Confirm": "true"},
+			wantResponseType: "json",
+			wantResponseBody: &map[string]interface{}{},
+		},
+		{
+			name:             "x-confirm-v5",
+			apiVersion:       "application/vnd.go.cd.v5+json",
+			wantHeaders:      map[string]string{"X-GoCD-Confirm": "true"},
+			wantResponseType: "json",
+			wantResponseBody: &map[string]interface{}{},
+		},
+		{
+			name:             "x-confirm-v6",
+			apiVersion:       "application/vnd.go.cd.v6+json",
+			wantHeaders:      map[string]string{"X-GoCD-Confirm": "true"},
+			wantResponseType: "json",
+			wantResponseBody: &map[string]interface{}{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &APIClientRequest{}
+			choosePipelineConfirmHeader(request, tt.apiVersion)
+			assert.Equal(t, tt.wantHeaders, request.Headers)
+			assert.Equal(t, tt.wantResponseBody, request.ResponseBody)
+			assert.Equal(t, tt.wantResponseType, request.ResponseType)
+		})
+	}
 }

--- a/gocd/pipelineconfig_test.go
+++ b/gocd/pipelineconfig_test.go
@@ -19,19 +19,7 @@ func TestPipelineConfig(t *testing.T) {
 					Branch:      "master",
 				},
 			}},
-			Stages: []*Stage{{
-				Name: "defaultStage",
-				Jobs: []*Job{{
-					Name: "defaultJob",
-					Tasks: []*Task{{
-						Type: "exec",
-						Attributes: TaskAttributes{
-							RunIf:   []string{"passed"},
-							Command: "ls",
-						},
-					}},
-				}},
-			}},
+			Stages: buildMockPipelineStages(),
 		}
 
 		ctx := context.Background()
@@ -183,4 +171,20 @@ func TestPipelineConfig(t *testing.T) {
 		assert.Equal(t, "The pipeline 'new_pipeline' was deleted successfully.", message)
 
 	}
+}
+
+func buildMockPipelineStages() []*Stage {
+	return []*Stage{{
+		Name: "defaultStage",
+		Jobs: []*Job{{
+			Name: "defaultJob",
+			Tasks: []*Task{{
+				Type: "exec",
+				Attributes: TaskAttributes{
+					RunIf:   []string{"passed"},
+					Command: "ls",
+				},
+			}},
+		}},
+	}}
 }

--- a/gocd/pipelineconfig_test.go
+++ b/gocd/pipelineconfig_test.go
@@ -185,6 +185,18 @@ func buildMockPipelineStages() []*Stage {
 					Command: "ls",
 				},
 			}},
+			Tabs:                 make([]*Tab, 0),
+			Artifacts:            make([]*Artifact, 0),
+			EnvironmentVariables: make([]*EnvironmentVariable, 0),
+			Resources:            []string{},
 		}},
+		Approval: &Approval{
+			Type: "success",
+			Authorization: &Authorization{
+				Users: make([]string, 0),
+				Roles: make([]string, 0),
+			},
+		},
+		EnvironmentVariables: make([]*EnvironmentVariable, 0),
 	}}
 }


### PR DESCRIPTION
Converted mock tests cases to integration tests for the pipeline actions Pause/UnPause/ReleaseLock

## Description
Deleted the mocked endpoints, and replaced them with integration tests with a GoCD docker instance.
_Note_: The releaselock pipeline would need to be run and put in a locked state to be able to test this. The test case for this, is significantly more complex, as it would require running a pipeline and waiting for it to fail, so will be done in a subsequent PR>

## Motivation and Context
As we are testing multiple versions of GoCD, rather than having to mock the endpoints for each version, we can just hit a real version of GoCD.

## How Has This Been Tested?
Testcases have been written and are included in this PR.
