### PR TITLE
Fix bug where the Makefile would always use the same GoCD version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
 
 matrix:
   fast_finish: true
+  allow_failures:
+     - env: GOCD_VERSION=v17.10.0 CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage
 
 before_install:
   - make before_install

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL:=/bin/bash
 TEST?=$$(go list ./... |grep -v 'vendor')
 
 GO_TARGETS= ./cli ./gocd ./gocd-*generator
-GOCD_VERSION= v17.10.0
+GOCD_VERSION?= v18.7.0
 
 format:
 	gofmt -w -s .


### PR DESCRIPTION
The missing "?=" in the Makefile meant the GoCD versions was being ignored. This allows the older version to fail in travis, and pass. The intention is to go back and fix those issues.

## Description
Allows GoCD 17.10.0 to fail, and makes sure the GoCD version is passed into the test cases.