### PR TITLE
Changed to more reasonable build variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,4 +16,4 @@ coverage:
     patch:
       default:
         enabled: yes
-        target: 80%
+        target: 60%

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ ignore:
 coverage:
   precision: 2
   round: down
-  range: "90...100"
+  range: "80...100"
   status:
     project:
       default:


### PR DESCRIPTION
Allow more green in the coverage PR, and lower bar for patch coverage.

## Description
The coverage requirements for patches and the badge colours are quite strict and set a very high bar for small PR's. We are keeping the 90% project coverage goal, but reducing the size of the patch coverage required for a PR to be approved.

Due to the combination of GoCD and golang versions, let's only support 2 versions of golang.