### PR TITLE
Unmarshalling gocd.Job JSON no longer strips timeout property #159

### DIFF
--- a/gocd/resource_jobs.go
+++ b/gocd/resource_jobs.go
@@ -29,17 +29,20 @@ func (j *Job) Validate() (err error) {
 
 // UnmarshalJSON and handle "never", "null", and integers.
 func (tf *TimeoutField) UnmarshalJSON(b []byte) (err error) {
-	value := string(b)
-	var valInt int
+	// The target `valint` value has -1 so that we have a value which does not match
+	// the expected value (probably) and we can ensure the methods is working and not just putting
+	// the default in (which is `0`).
+	valInt := -1
 
-	if value == `"never"` || value == `"null"` || value == "null" {
+	value := string(b)
+
+	if value == `"never"` || value == `"null"` {
 		valInt = 0
 	} else {
 		valInt, err = strconv.Atoi(value)
 
 	}
-	valTf := TimeoutField(valInt)
-	tf = &valTf
+	*tf = TimeoutField(valInt)
 
 	return
 }

--- a/gocd/resource_jobs.go
+++ b/gocd/resource_jobs.go
@@ -36,7 +36,7 @@ func (tf *TimeoutField) UnmarshalJSON(b []byte) (err error) {
 
 	value := string(b)
 
-	if value == `"never"` || value == `"null"` {
+	if value == `"never"` || value == `"null"` || value == "never" || value == "null" {
 		valInt = 0
 	} else {
 		valInt, err = strconv.Atoi(value)

--- a/gocd/resource_jobs_test.go
+++ b/gocd/resource_jobs_test.go
@@ -1,9 +1,9 @@
 package gocd
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"encoding/json"
 )
 
 func TestResourceJobsJSONMarshal(t *testing.T) {

--- a/gocd/resource_jobs_test.go
+++ b/gocd/resource_jobs_test.go
@@ -3,20 +3,46 @@ package gocd
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"encoding/json"
 )
 
-func TestResourceJobs(t *testing.T) {
+func TestResourceJobsJSONMarshal(t *testing.T) {
 	for _, test := range []struct {
-		expected string
-		input    int
+		want    string
+		timeout int
 	}{
-		{expected: "5", input: 5},
+		{want: "5", timeout: 5},
 	} {
-		tf := TimeoutField(test.input)
+		tf := TimeoutField(test.timeout)
 
 		b, err := tf.MarshalJSON()
 
-		assert.Equal(t, test.expected, string(b))
+		assert.Equal(t, test.want, string(b))
 		assert.NoError(t, err)
+	}
+}
+
+func TestResourceJobsJSONUnmarshal(t *testing.T) {
+	for _, test := range []struct {
+		want    TimeoutField
+		tf      TimeoutField
+		timeout []byte
+	}{
+		// The `tf` attribute is present so that we have a value which does not match
+		// the expected value and we can ensure the test is working and not just putting
+		// the default in (which is `0`).
+		{want: TimeoutField(0), tf: TimeoutField(-1), timeout: []byte(`"never"`)},
+		{want: TimeoutField(0), tf: TimeoutField(-1), timeout: []byte(`"null"`)},
+		{want: TimeoutField(1), tf: TimeoutField(-1), timeout: []byte("1")},
+		{want: TimeoutField(3), tf: TimeoutField(-1), timeout: []byte("3")},
+		{want: TimeoutField(10), tf: TimeoutField(-1), timeout: []byte("10")},
+		{want: TimeoutField(23870), tf: TimeoutField(-1), timeout: []byte("23870")},
+	} {
+
+		err := json.Unmarshal(test.timeout, &test.tf)
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, test.want, test.tf)
+		}
 	}
 }


### PR DESCRIPTION
Modified the Timeout unmarshal function to stop always returning `0`.

## Description
The determination of the value was being correctly performed, but the assignment of the new timeout value was assigning the raw value to the pointer of the existing value.

This change will assign the raw value to the raw value of the timeout.

## Related Issue
 - #159 

## Motivation and Context
Timeouts were always being parsed as `0`, meaning they were being ignored.

## How Has This Been Tested?
New unit test cases have been added to focus on testing the unmarshal function itself.