### PR TITLE
Fixed a bug where error was being ignored when retrieving server version

### DIFF
--- a/gocd/server_version.go
+++ b/gocd/server_version.go
@@ -27,11 +27,13 @@ func (svs *ServerVersionService) Get(ctx context.Context) (v *ServerVersion, res
 	}
 
 	v = &ServerVersion{}
-	_, resp, err = svs.client.getAction(ctx, &APIClientRequest{
+	if _, resp, err = svs.client.getAction(ctx, &APIClientRequest{
 		Path:         "version",
 		ResponseBody: v,
 		APIVersion:   apiV1,
-	})
+	}); err != nil {
+		return
+	}
 
 	err = v.parseVersion()
 


### PR DESCRIPTION
Made sure any error from the GoCD api call is checked before continuing.

## Description
Added an if check on the gocd server version api call, and check if the error is not nil. If the error is not nil, return the error