### PR TITLE
Add additional artifact_origin property to task attributes (gocd 18.7.0)

### DIFF
--- a/gocd/jobs.go
+++ b/gocd/jobs.go
@@ -97,6 +97,7 @@ type TaskAttributes struct {
 	Destination         string                      `json:"destination,omitempty"`
 	PluginConfiguration *TaskPluginConfiguration    `json:"plugin_configuration,omitempty"`
 	Configuration       []PluginConfigurationKVPair `json:"configuration,omitempty"`
+	ArtifactOrigin      string                      `json:"artifact_origin,omitempty"`
 }
 
 // TaskPluginConfiguration is for specifying options for pluggable task


### PR DESCRIPTION
## Description
gocd 18.7.0 adds a new property to fetch task attributes (artifact_origin). Without this PR this library can not be used to create fetch tasks for this or later versions of gocd.

## Related Issue
Fixes https://github.com/beamly/go-gocd/issues/166

## Motivation and Context
Without this PR this library can not be used to create fetch tasks for this or later versions of gocd.

## How Has This Been Tested?
Acceptance test that builds a pipeline has been augmented to build a simple VSM with a fetch task. This test fails if artifact_origin isn't specified.
 