### PR TITLE
Allow empty environment variables

### DIFF
--- a/gocd/jobs.go
+++ b/gocd/jobs.go
@@ -2,6 +2,7 @@ package gocd
 
 import (
 	"context"
+	"encoding/json"
 )
 
 const (
@@ -66,6 +67,35 @@ type EnvironmentVariable struct {
 	Value          string `json:"value,omitempty"`
 	EncryptedValue string `json:"encrypted_value,omitempty"`
 	Secure         bool   `json:"secure"`
+}
+
+type unencryptedEnvironmentVariable struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Secure bool   `json:"secure"`
+}
+
+type encryptedEnvironmentVariable struct {
+	Name           string `json:"name"`
+	EncryptedValue string `json:"encrypted_value"`
+	Secure         bool   `json:"secure"`
+}
+
+// MarshalJSON is a custom JSON Marhsaller for EnvironmentVariables to handle empty values
+func (v *EnvironmentVariable) MarshalJSON() ([]byte, error) {
+	if v.EncryptedValue != "" {
+		return json.Marshal(&encryptedEnvironmentVariable{
+			Name:           v.Name,
+			Secure:         v.Secure,
+			EncryptedValue: v.EncryptedValue,
+		})
+	}
+
+	return json.Marshal(&unencryptedEnvironmentVariable{
+		Name:   v.Name,
+		Secure: v.Secure,
+		Value:  v.Value,
+	})
 }
 
 // PluginConfigurationKVPair describes a key/value pair of plugin configurations.

--- a/gocd/jobs_test.go
+++ b/gocd/jobs_test.go
@@ -44,9 +44,9 @@ func testJobJSONString(t *testing.T) {
 func testEmptyEnvironmentVariableValue(t *testing.T) {
 	jb := Job{
 		Name: "test-job",
-                EnvironmentVariables:[]*EnvironmentVariable{
-			&EnvironmentVariable{
-				Name: "test",
+		EnvironmentVariables: []*EnvironmentVariable{
+			{
+				Name:  "test",
 				Value: "",
 			},
 		},

--- a/gocd/jobs_test.go
+++ b/gocd/jobs_test.go
@@ -19,6 +19,7 @@ func TestTaskValidate(t *testing.T) {
 	t.Run("SuccessAnt", taskValidateSuccessAnt)
 	t.Run("JSONString", testJobJSONString)
 	t.Run("JSONStringFail", testJobJSONStringFail)
+	t.Run("EmptyEnvironmentVariableValue", testEmptyEnvironmentVariableValue)
 }
 
 func testJobJSONStringFail(t *testing.T) {
@@ -37,6 +38,34 @@ func testJobJSONString(t *testing.T) {
 	assert.Equal(
 		t, `{
   "name": "test-job"
+}`, j)
+}
+
+func testEmptyEnvironmentVariableValue(t *testing.T) {
+	jb := Job{
+		Name: "test-job",
+                EnvironmentVariables:[]*EnvironmentVariable{
+			&EnvironmentVariable{
+				Name: "test",
+				Value: "",
+			},
+		},
+	}
+
+	j, err := jb.JSONString()
+	if err != nil {
+		assert.Nil(t, err)
+	}
+	assert.Equal(
+		t, `{
+  "name": "test-job",
+  "environment_variables": [
+    {
+      "name": "test",
+      "value": "",
+      "secure": false
+    }
+  ]
 }`, j)
 }
 


### PR DESCRIPTION
## Description
GoCD allows empty environment variables. However as `omitempty` is used for both `value` and `encrypted_value`, invalid JSON is sent to GoCD when an empty value is provided.

## Related Issue
Previously the following HCL would cause the error below:
```
resource "gocd_pipeline_stage" "test" {
  name = "test"
  pipeline = "${gocd_pipeline.test.name}"
  jobs = ["${data.gocd_job_definition.job.json}"]

  environment_variables = [
    {
      name = "plain"
      value = "plain"
    },
    {
      name = "empty"
      value = ""
    },
  ]
}
```
Error:
``` 
"message": "Json `{\"name\":\"empty\",\"secure\":false}` does not contain property 'value'"
```

## How Has This Been Tested?
Both running against gocd and a unit test in `jobs_test.go`.
