### PR TITLE
Support versioning of the Template Config API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - GOCD_LOG_LEVEL=DEBUG
   matrix:
     - GOCD_VERSION=v17.10.0
-    - GOCD_VERSION=v18.7.0
+    - GOCD_VERSION=v18.12.0
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL:=/bin/bash
 TEST?=$$(go list ./... |grep -v 'vendor')
 
 GO_TARGETS= ./cli ./gocd ./gocd-*generator
-GOCD_VERSION?= v18.7.0
+GOCD_VERSION?= v18.12.0
 
 format:
 	gofmt -w -s .

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -2,6 +2,7 @@ package gocd
 
 import (
 	"context"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -51,11 +52,21 @@ func testPipelineServiceUnPause(t *testing.T) {
 
 		assert.Equal(t, mockPipeline, pausePipeline)
 
-		pp, _, err := intClient.Pipelines.Unpause(ctx, pipelineName)
+		// From 18.8.0 onwards pipelines are no-longer created paused
+		v, _, err := client.ServerVersion.Get(context.Background())
+
+		pausedBeforeVersion, _ := version.NewVersion("18.8.0")
+		if v.VersionParts.LessThan(pausedBeforeVersion) {
+			pp, _, err := intClient.Pipelines.Unpause(ctx, pipelineName)
+			assert.NoError(t, err)
+			assert.True(t, pp)
+		}
+
+		pp, _, err := intClient.Pipelines.Pause(ctx, pipelineName)
 		assert.NoError(t, err)
 		assert.True(t, pp)
 
-		pp, _, err = intClient.Pipelines.Pause(ctx, pipelineName)
+		pp, _, err = intClient.Pipelines.Unpause(ctx, pipelineName)
 		assert.NoError(t, err)
 		assert.True(t, pp)
 

--- a/gocd/pipelinetemplate.go
+++ b/gocd/pipelinetemplate.go
@@ -48,10 +48,15 @@ type PipelineTemplate struct {
 
 // Get a single PipelineTemplate object in the GoCD API.
 func (pts *PipelineTemplatesService) Get(ctx context.Context, name string) (pt *PipelineTemplate, resp *APIResponse, err error) {
+	apiVersion, err := pts.client.getAPIVersion(ctx, "admin/templates/:template_name")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	pt = &PipelineTemplate{}
 	_, resp, err = pts.client.getAction(ctx, &APIClientRequest{
 		Path:         "admin/templates/" + name,
-		APIVersion:   apiV3,
+		APIVersion:   apiVersion,
 		ResponseBody: pt,
 	})
 
@@ -60,10 +65,15 @@ func (pts *PipelineTemplatesService) Get(ctx context.Context, name string) (pt *
 
 // List all PipelineTemplate objects in the GoCD API.
 func (pts *PipelineTemplatesService) List(ctx context.Context) (pt []*PipelineTemplate, resp *APIResponse, err error) {
+	apiVersion, err := pts.client.getAPIVersion(ctx, "admin/templates")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	ptr := PipelineTemplatesResponse{}
 	_, resp, err = pts.client.getAction(ctx, &APIClientRequest{
 		Path:         "admin/templates",
-		APIVersion:   apiV3,
+		APIVersion:   apiVersion,
 		ResponseBody: &ptr,
 	})
 	pt = ptr.Embedded.Templates
@@ -73,6 +83,10 @@ func (pts *PipelineTemplatesService) List(ctx context.Context) (pt []*PipelineTe
 
 // Create a new PipelineTemplate object in the GoCD API.
 func (pts *PipelineTemplatesService) Create(ctx context.Context, name string, st []*Stage) (ptr *PipelineTemplate, resp *APIResponse, err error) {
+	apiVersion, err := pts.client.getAPIVersion(ctx, "admin/templates")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	pt := PipelineTemplateRequest{
 		Name:   name,
@@ -82,7 +96,7 @@ func (pts *PipelineTemplatesService) Create(ctx context.Context, name string, st
 
 	_, resp, err = pts.client.postAction(ctx, &APIClientRequest{
 		Path:         "admin/templates",
-		APIVersion:   apiV3,
+		APIVersion:   apiVersion,
 		RequestBody:  pt,
 		ResponseBody: ptr,
 	})
@@ -93,10 +107,15 @@ func (pts *PipelineTemplatesService) Create(ctx context.Context, name string, st
 
 // Update an PipelineTemplate object in the GoCD API.
 func (pts *PipelineTemplatesService) Update(ctx context.Context, name string, template *PipelineTemplate) (ptr *PipelineTemplate, resp *APIResponse, err error) {
+	apiVersion, err := pts.client.getAPIVersion(ctx, "admin/templates/:template_name")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	ptr = &PipelineTemplate{}
 	_, resp, err = pts.client.putAction(ctx, &APIClientRequest{
 		Path:       "admin/templates/" + name,
-		APIVersion: apiV3,
+		APIVersion: apiVersion,
 		RequestBody: &PipelineTemplateRequest{
 			Name:    name,
 			Stages:  template.Stages,

--- a/gocd/pipelinetemplate_test.go
+++ b/gocd/pipelinetemplate_test.go
@@ -14,11 +14,11 @@ func TestPipelineTemplate(t *testing.T) {
 	setup()
 	defer teardown()
 
-        mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
-                assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-                j, _ := ioutil.ReadFile("test/resources/version.1.json")
-                fmt.Fprint(w, string(j))
-        })
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+		j, _ := ioutil.ReadFile("test/resources/version.1.json")
+		fmt.Fprint(w, string(j))
+	})
 
 	t.Run("List", testListPipelineTemplates)
 	t.Run("Get", testGetPipelineTemplate)
@@ -60,7 +60,8 @@ func TestPipelineTemplateCreate(t *testing.T) {
 
 	mux.HandleFunc("/api/admin/templates", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-		assert.Equal(t, apiV1, r.Header.Get("Accept"))
+		apiVersion, _ := client.getAPIVersion(context.Background(), "admin/templates")
+		assert.Equal(t, apiVersion, r.Header.Get("Accept"))
 
 		j, _ := ioutil.ReadFile("test/resources/pipelinetemplate.2.json")
 		w.Header().Set("Etag", "mock-etag")

--- a/gocd/pipelinetemplate_test.go
+++ b/gocd/pipelinetemplate_test.go
@@ -14,6 +14,12 @@ func TestPipelineTemplate(t *testing.T) {
 	setup()
 	defer teardown()
 
+        mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+                assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+                j, _ := ioutil.ReadFile("test/resources/version.1.json")
+                fmt.Fprint(w, string(j))
+        })
+
 	t.Run("List", testListPipelineTemplates)
 	t.Run("Get", testGetPipelineTemplate)
 	t.Run("Delete", testDeletePipelineTemplate)
@@ -54,7 +60,7 @@ func TestPipelineTemplateCreate(t *testing.T) {
 
 	mux.HandleFunc("/api/admin/templates", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
-		assert.Equal(t, apiV3, r.Header.Get("Accept"))
+		assert.Equal(t, apiV1, r.Header.Get("Accept"))
 
 		j, _ := ioutil.ReadFile("test/resources/pipelinetemplate.2.json")
 		w.Header().Set("Etag", "mock-etag")
@@ -153,7 +159,6 @@ func testListPipelineTemplates(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Len(t, templates, 1)
-
 	for _, attribute := range []EqualityTest{
 		{templates[0].Name, "template0"},
 		{templates[0].Embedded.Pipelines[0].Name, "up42"},

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -35,6 +35,16 @@ func init() {
 				newServerAPI("16.12.0", apiV2),
 				newServerAPI("17.9.0", apiV3),
 				newServerAPI("18.3.0", apiV4)),
+			"/api/admin/templates": newVersionCollection(
+				newServerAPI("16.10.0", apiV1),
+				newServerAPI("16.11.0", apiV2),
+				newServerAPI("17.1.0", apiV3),
+				newServerAPI("18.7.0", apiV4)),
+			"/api/admin/templates/:template_name": newVersionCollection(
+				newServerAPI("16.10.0", apiV1),
+				newServerAPI("16.11.0", apiV2),
+				newServerAPI("17.1.0", apiV3),
+				newServerAPI("18.7.0", apiV4)),
 		},
 	}
 }

--- a/gocd/test/resources/version.1.json
+++ b/gocd/test/resources/version.1.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://build.go.cd/go/api/version"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/#version"
+    }
+  },
+  "version": "16.10.0",
+  "build_number": "3348",
+  "git_sha": "a7a5717cbd60c30006314fb8dd529796c93adaf0",
+  "full_version": "16.6.0 (3348-a7a5717cbd60c30006314fb8dd529796c93adaf0)",
+  "commit_url": "https://github.com/gocd/gocd/commits/a7a5717cbd60c30006314fb8dd529796c93adaf0"
+}


### PR DESCRIPTION
Version 18.11.0 of GoCD removes Template Config API v3, see https://www.gocd.org/releases/#18-11-0

This PR adds versioning to this API (following the pattern used for the Pipeline Config API), moves the 18.x.y tests from 18.7.0 to 18.12.0, and fixes another test (pipelines are no-longer created paused from 18.8.0 onwards).

Tests pass for 18.12.0 and 17.10.0