### PR TITLE
StageInstance.RerunOfCounter should be an int (not a string)

### DIFF
--- a/gocd/gocd.go
+++ b/gocd/gocd.go
@@ -404,3 +404,8 @@ func createErrorResponseMessage(body string) (resp string) {
 func String(v string) *string {
 	return &v
 }
+
+// Int returns a pointer to the int value passed in. Allows `omitempty` to function in json building
+func Int(v int) *int {
+	return &v
+}

--- a/gocd/stage_instance.go
+++ b/gocd/stage_instance.go
@@ -13,7 +13,7 @@ type StageInstance struct {
 	Counter           string `json:"counter,omitempty"`
 	OperatePermission bool   `json:"operate_permission,omitempty"`
 	Result            string `json:"result,omitempty"`
-	RerunOfCounter    string `json:"rerun_of_counter,omitempty"`
+	RerunOfCounter    int    `json:"rerun_of_counter,omitempty"`
 }
 
 // codebeat:enable[TOO_MANY_IVARS]

--- a/gocd/stage_instance.go
+++ b/gocd/stage_instance.go
@@ -13,7 +13,7 @@ type StageInstance struct {
 	Counter           string `json:"counter,omitempty"`
 	OperatePermission bool   `json:"operate_permission,omitempty"`
 	Result            string `json:"result,omitempty"`
-	RerunOfCounter    int    `json:"rerun_of_counter,omitempty"`
+	RerunOfCounter    *int   `json:"rerun_of_counter,omitempty"`
 }
 
 // codebeat:enable[TOO_MANY_IVARS]

--- a/gocd/stage_instance_test.go
+++ b/gocd/stage_instance_test.go
@@ -41,6 +41,7 @@ func testStageInstanceJSONString(t *testing.T) {
 		ID:                13,
 		OperatePermission: true,
 		Scheduled:         true,
+		RerunOfCounter:    1,
 	}
 	j, err := s.JSONString()
 	if err != nil {
@@ -65,7 +66,8 @@ func testStageInstanceJSONString(t *testing.T) {
   "approved_by": "admin",
   "counter": "1",
   "operate_permission": true,
-  "result": "Failed"
+  "result": "Failed",
+  "rerun_of_counter": 1
 }`, j)
 }
 

--- a/gocd/stage_instance_test.go
+++ b/gocd/stage_instance_test.go
@@ -41,7 +41,7 @@ func testStageInstanceJSONString(t *testing.T) {
 		ID:                13,
 		OperatePermission: true,
 		Scheduled:         true,
-		RerunOfCounter:    1,
+		RerunOfCounter:    Int(1),
 	}
 	j, err := s.JSONString()
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
StageInstance.RerunOfCounter was assumed to be a string, but is actually an integer.

## Description
<!--- Describe your changes in detail -->
Our usage of this library failed when we had pipelines that had been rerun.

It's understandable, as the type `rerun_of_counter` isn't described here (and always mentioned as `null`): https://api.gocd.org/current/#get-stage-history

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is the error given by this library:
`json: cannot unmarshal number into Go struct field StageInstance.rerun_of_counter of type string`

Let me know if you need me to create an issue for this too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Here's a real-world example of a stage containing reruns:

```
                {
                    "result": "Failed",
                    "jobs": [
                        {
                            "state": "Completed",
                            "result": "Passed",
                            "name": "obfuscated1",
                            "id": 399786,
                            "scheduled_date": 1542096777963
                        },
                        {
                            "state": "Completed",
                            "result": "Failed",
                            "name": "obfuscated2",
                            "id": 399787,
                            "scheduled_date": 1542098637511
                        }
                    ],
                    "name": "obfuscated",
                    "rerun_of_counter": 1,
                    "approval_type": "success",
                    "scheduled": true,
                    "operate_permission": true,
                    "approved_by": "obfuscated",
                    "can_run": true,
                    "id": 369813,
                    "counter": "2"
                },
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test for StageInstance (`gocd/stage_instance_test.go`) updated.

## Screenshots (if appropriate):
![skarmklipp 2019-02-11 15 05 36](https://user-images.githubusercontent.com/62675/52568799-0e8d3380-2e10-11e9-9121-a486873b1c85.png)

