### PR TITLE
Run tests against GoCD 0.19.5 and fix issues (new version of PluginInfo and Roles APIs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - GOCD_LOG_LEVEL=DEBUG
   matrix:
     - GOCD_VERSION=v17.10.0
-    - GOCD_VERSION=v19.1.0
+    - GOCD_VERSION=v19.5.0
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL:=/bin/bash
 TEST?=$$(go list ./... |grep -v 'vendor')
 
 GO_TARGETS= ./cli ./gocd ./gocd-*generator
-GOCD_VERSION?= v18.12.0
+GOCD_VERSION?= v19.5.0
 
 format:
 	gofmt -w -s .

--- a/gocd/pipeline_action_test.go
+++ b/gocd/pipeline_action_test.go
@@ -75,7 +75,7 @@ func testPipelineServiceUnPause(t *testing.T) {
 		assert.False(t, pp)
 
 		deleteResponse, _, err := intClient.PipelineConfigs.Delete(ctx, pipelineName)
-		assert.Equal(t, "The pipeline 'test-pipeline-un-pause' was deleted successfully.", deleteResponse)
+		assert.Contains(t, deleteResponse, "'test-pipeline-un-pause' was deleted successfully")
 	}
 
 }

--- a/gocd/pipeline_test.go
+++ b/gocd/pipeline_test.go
@@ -87,7 +87,7 @@ func testPipelineServiceCreateDelete(t *testing.T) {
 	p := Pipeline{
 		LabelTemplate:         "${COUNT}",
 		EnablePipelineLocking: true,
-		Name: "testPipelineServiceCreateDelete",
+		Name:                  "testPipelineServiceCreateDelete",
 		Materials: []Material{
 			{
 				Type: "git",
@@ -144,7 +144,7 @@ func testPipelineServiceCreateDelete(t *testing.T) {
 
 	msg, _, err := intClient.PipelineConfigs.Delete(ctx, p.Name)
 	assert.NoError(t, err)
-	assert.Equal(t, "The pipeline 'testPipelineServiceCreateDelete' was deleted successfully.", msg)
+	assert.Contains(t, msg, "'testPipelineServiceCreateDelete' was deleted successfully")
 }
 
 func testPipelineServiceGet(t *testing.T) {

--- a/gocd/pipeline_test.go
+++ b/gocd/pipeline_test.go
@@ -87,7 +87,7 @@ func testPipelineServiceCreateDelete(t *testing.T) {
 	p := Pipeline{
 		LabelTemplate:         "${COUNT}",
 		EnablePipelineLocking: true,
-		Name:                  "testPipelineServiceCreateDelete",
+		Name: "testPipelineServiceCreateDelete",
 		Materials: []Material{
 			{
 				Type: "git",

--- a/gocd/pipelineconfig_test.go
+++ b/gocd/pipelineconfig_test.go
@@ -173,7 +173,7 @@ func TestPipelineConfig(t *testing.T) {
 	assert.Equal(t, expected, updatedP)
 
 	message, _, err := intClient.PipelineConfigs.Delete(ctx, input.Name)
-	assert.Equal(t, "The pipeline 'test_pipeline_config' was deleted successfully.", message)
+	assert.Contains(t, message, "'test_pipeline_config' was deleted successfully")
 
 }
 

--- a/gocd/plugin_test.go
+++ b/gocd/plugin_test.go
@@ -2,6 +2,7 @@ package gocd
 
 import (
 	"context"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -16,20 +17,28 @@ func TestPluginApi(t *testing.T) {
 
 func testPluginAPIList(t *testing.T) {
 	if runIntegrationTest(t) {
+		var pi *Plugin = nil
+
 		ctx := context.Background()
 		plugins, _, err := intClient.Plugins.List(ctx)
 		assert.NoError(t, err)
 
 		assert.NotNil(t, plugins)
 		assert.NotNil(t, plugins.Links.Get("Doc"))
-		assert.Equal(t, "https://api.gocd.org/#plugin-info", plugins.Links.Get("Doc").URL.String())
 		assert.NotNil(t, plugins.Links.Get("Self"))
 		assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/plugin_info", plugins.Links.Get("Self").URL.String())
 
 		assert.NotNil(t, plugins.Embedded)
 		assert.NotNil(t, plugins.Embedded.PluginInfo)
 		assert.Len(t, plugins.Embedded.PluginInfo, 5)
-		pi := plugins.Embedded.PluginInfo[0]
+
+		for _, pInfo := range plugins.Embedded.PluginInfo {
+			if pInfo.ID == "yum" {
+				pi = pInfo
+			}
+		}
+
+		assert.NotNil(t, pi)
 		assert.Equal(t, "yum", pi.ID)
 
 		apiVersion, err := client.getAPIVersion(ctx, "admin/plugin_info")
@@ -37,6 +46,7 @@ func testPluginAPIList(t *testing.T) {
 
 		switch apiVersion {
 		case apiV3:
+			assert.Equal(t, "https://api.gocd.org/#plugin-info", plugins.Links.Get("Doc").URL.String())
 			assert.Equal(t, "package-repository", pi.Type)
 			assert.Equal(t, "active", pi.Status.State)
 			assert.Equal(t, "Yum Plugin", pi.About.Name)
@@ -44,6 +54,17 @@ func testPluginAPIList(t *testing.T) {
 			assert.Equal(t, "Package Spec", pi.ExtensionInfo.PackageSettings.Configurations[0].Metadata.DisplayName)
 			assert.Equal(t, true, pi.ExtensionInfo.PackageSettings.Configurations[0].Metadata.Required)
 		case apiV4:
+			assert.Equal(t, "https://api.gocd.org/#plugin-info", plugins.Links.Get("Doc").URL.String())
+			assert.Equal(t, "active", pi.Status.State)
+			assert.Equal(t, "Yum Plugin", pi.About.Name)
+			assert.Equal(t, "package-repository", pi.Extensions[0].Type)
+			assert.Equal(t, "PACKAGE_SPEC", pi.Extensions[0].PackageSettings.Configurations[0].Key)
+			assert.Equal(t, "Package Spec", pi.Extensions[0].PackageSettings.Configurations[0].Metadata.DisplayName)
+			assert.Equal(t, true, pi.Extensions[0].PackageSettings.Configurations[0].Metadata.Required)
+		case apiV5:
+			v, _, err := intClient.ServerVersion.Get(ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("https://api.gocd.org/%s/#plugin-info", v.Version), plugins.Links.Get("Doc").URL.String())
 			assert.Equal(t, "active", pi.Status.State)
 			assert.Equal(t, "Yum Plugin", pi.About.Name)
 			assert.Equal(t, "package-repository", pi.Extensions[0].Type)
@@ -64,7 +85,6 @@ func testPluginAPIGet(t *testing.T) {
 
 		assert.NotNil(t, plugin)
 		assert.NotNil(t, plugin.Links.Get("Doc"))
-		assert.Equal(t, "https://api.gocd.org/#plugin-info", plugin.Links.Get("Doc").URL.String())
 		assert.NotNil(t, plugin.Links.Get("Self"))
 		assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/plugin_info/yum", plugin.Links.Get("Self").URL.String())
 
@@ -75,6 +95,7 @@ func testPluginAPIGet(t *testing.T) {
 
 		switch apiVersion {
 		case apiV3:
+			assert.Equal(t, "https://api.gocd.org/#plugin-info", plugin.Links.Get("Doc").URL.String())
 			assert.Equal(t, "package-repository", plugin.Type)
 			assert.Equal(t, "active", plugin.Status.State)
 			assert.Equal(t, "Yum Plugin", plugin.About.Name)
@@ -82,6 +103,17 @@ func testPluginAPIGet(t *testing.T) {
 			assert.Equal(t, "Package Spec", plugin.ExtensionInfo.PackageSettings.Configurations[0].Metadata.DisplayName)
 			assert.Equal(t, true, plugin.ExtensionInfo.PackageSettings.Configurations[0].Metadata.Required)
 		case apiV4:
+			assert.Equal(t, "https://api.gocd.org/#plugin-info", plugin.Links.Get("Doc").URL.String())
+			assert.Equal(t, "active", plugin.Status.State)
+			assert.Equal(t, "Yum Plugin", plugin.About.Name)
+			assert.Equal(t, "package-repository", plugin.Extensions[0].Type)
+			assert.Equal(t, "PACKAGE_SPEC", plugin.Extensions[0].PackageSettings.Configurations[0].Key)
+			assert.Equal(t, "Package Spec", plugin.Extensions[0].PackageSettings.Configurations[0].Metadata.DisplayName)
+			assert.Equal(t, true, plugin.Extensions[0].PackageSettings.Configurations[0].Metadata.Required)
+		case apiV5:
+			v, _, err := intClient.ServerVersion.Get(ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("https://api.gocd.org/%s/#plugin-info", v.Version), plugin.Links.Get("Doc").URL.String())
 			assert.Equal(t, "active", plugin.Status.State)
 			assert.Equal(t, "Yum Plugin", plugin.About.Name)
 			assert.Equal(t, "package-repository", plugin.Extensions[0].Type)

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -34,7 +34,8 @@ func init() {
 				newServerAPI("16.7.0", apiV1),
 				newServerAPI("16.12.0", apiV2),
 				newServerAPI("17.9.0", apiV3),
-				newServerAPI("18.3.0", apiV4)),
+				newServerAPI("18.3.0", apiV4),
+				newServerAPI("19.3.0", apiV5)),
 			"/api/admin/templates": newVersionCollection(
 				newServerAPI("16.10.0", apiV1),
 				newServerAPI("16.11.0", apiV2),
@@ -45,6 +46,12 @@ func init() {
 				newServerAPI("16.11.0", apiV2),
 				newServerAPI("17.1.0", apiV3),
 				newServerAPI("18.7.0", apiV4)),
+			"/api/admin/security/roles": newVersionCollection(
+				newServerAPI("17.5.0", apiV1),
+				newServerAPI("19.2.0", apiV2)),
+			"/api/admin/security/roles/:role_name": newVersionCollection(
+				newServerAPI("17.5.0", apiV1),
+				newServerAPI("19.2.0", apiV2)),
 		},
 	}
 }

--- a/gocd/resource_test.go
+++ b/gocd/resource_test.go
@@ -21,7 +21,7 @@ func testResourceVersioned(t *testing.T) {
 		"PipelineTemplate":        &PipelineTemplate{Version: "mock-version1"},
 		"PipelineConfigRequest":   &PipelineConfigRequest{Pipeline: &Pipeline{Version: "mock-version1"}},
 		"PipelineTemplateRequest": &PipelineTemplateRequest{Version: "mock-version1"},
-		"Role": &Role{Version: "mock-version1"},
+		"Role":                    &Role{Version: "mock-version1"},
 	}
 	for key, ver := range vers {
 		t.Run(key, func(t *testing.T) {

--- a/gocd/resource_test.go
+++ b/gocd/resource_test.go
@@ -21,7 +21,7 @@ func testResourceVersioned(t *testing.T) {
 		"PipelineTemplate":        &PipelineTemplate{Version: "mock-version1"},
 		"PipelineConfigRequest":   &PipelineConfigRequest{Pipeline: &Pipeline{Version: "mock-version1"}},
 		"PipelineTemplateRequest": &PipelineTemplateRequest{Version: "mock-version1"},
-		"Role":                    &Role{Version: "mock-version1"},
+		"Role": &Role{Version: "mock-version1"},
 	}
 	for key, ver := range vers {
 		t.Run(key, func(t *testing.T) {

--- a/gocd/role.go
+++ b/gocd/role.go
@@ -39,9 +39,14 @@ type RoleListWrapper struct {
 
 // Create a role
 func (rs *RoleService) Create(ctx context.Context, role *Role) (r *Role, resp *APIResponse, err error) {
+	apiVersion, err := rs.client.getAPIVersion(ctx, "admin/security/roles")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	r = &Role{}
 	_, resp, err = rs.client.postAction(ctx, &APIClientRequest{
-		APIVersion:   apiV1,
+		APIVersion:   apiVersion,
 		Path:         "admin/security/roles",
 		RequestBody:  role,
 		ResponseBody: r,
@@ -52,11 +57,14 @@ func (rs *RoleService) Create(ctx context.Context, role *Role) (r *Role, resp *A
 
 // List all roles
 func (rs *RoleService) List(ctx context.Context) (r []*Role, resp *APIResponse, err error) {
+	apiVersion, err := rs.client.getAPIVersion(ctx, "admin/security/roles")
+	if err != nil {
+		return nil, nil, err
+	}
 
 	wrapper := RoleListWrapper{}
-
 	_, resp, err = rs.client.getAction(ctx, &APIClientRequest{
-		APIVersion:   apiV1,
+		APIVersion:   apiVersion,
 		Path:         "admin/security/roles",
 		ResponseBody: &wrapper,
 	})
@@ -66,9 +74,13 @@ func (rs *RoleService) List(ctx context.Context) (r []*Role, resp *APIResponse, 
 
 // Get a single role by name
 func (rs *RoleService) Get(ctx context.Context, roleName string) (r *Role, resp *APIResponse, err error) {
+	apiVersion, err := rs.client.getAPIVersion(ctx, "admin/security/roles/:role_name")
+	if err != nil {
+		return nil, nil, err
+	}
 	r = &Role{}
 	_, resp, err = rs.client.getAction(ctx, &APIClientRequest{
-		APIVersion:   apiV1,
+		APIVersion:   apiVersion,
 		Path:         fmt.Sprintf("admin/security/roles/%s", roleName),
 		ResponseBody: r,
 	})
@@ -78,10 +90,14 @@ func (rs *RoleService) Get(ctx context.Context, roleName string) (r *Role, resp 
 
 // Delete a role by name
 func (rs *RoleService) Delete(ctx context.Context, roleName string) (result string, resp *APIResponse, err error) {
+	apiVersion, err := rs.client.getAPIVersion(ctx, "admin/security/roles/:role_name")
+	if err != nil {
+		return "", nil, err
+	}
 	return rs.client.deleteAction(
 		ctx,
 		fmt.Sprintf("admin/security/roles/%s", roleName),
-		apiV1,
+		apiVersion,
 	)
 
 }
@@ -90,9 +106,13 @@ func (rs *RoleService) Delete(ctx context.Context, roleName string) (result stri
 func (rs *RoleService) Update(ctx context.Context, roleName string, role *Role) (
 	r *Role, resp *APIResponse, err error) {
 
+	apiVersion, err := rs.client.getAPIVersion(ctx, "admin/security/roles/:role_name")
+	if err != nil {
+		return nil, nil, err
+	}
 	r = &Role{}
 	_, resp, err = rs.client.putAction(ctx, &APIClientRequest{
-		APIVersion:   apiV1,
+		APIVersion:   apiVersion,
 		Path:         fmt.Sprintf("admin/security/roles/%s", roleName),
 		ResponseBody: r,
 		RequestBody:  role,


### PR DESCRIPTION
## Description
Tests against GoCD 0.19.5 (latest version as of this PR). 

Introduces versioning for the Roles API and adds support for PluginInfo API v5.

## Motivation and Context
We want to use this with the latest versions of GoCD.

## How Has This Been Tested?
Updated integration tests.
