### PR TITLE
Added the abillity to schedule pipelines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/beamly/go-gocd
 
+go 1.11
+
 require (
 	github.com/Netflix/go-expect v0.0.0-20180928190340-9d1f4485533b // indirect
 	github.com/hashicorp/go-version v1.2.0

--- a/gocd/gocd_test.go
+++ b/gocd/gocd_test.go
@@ -71,6 +71,7 @@ func intSetup() {
 // teardown closes the test HTTP server.
 func teardown() {
 	server.Close()
+	cachedServerVersion = nil
 }
 
 func runIntegrationTest(t *testing.T) bool {

--- a/gocd/pipeline.go
+++ b/gocd/pipeline.go
@@ -3,6 +3,7 @@ package gocd
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // PipelinesService describes the HAL _link resource for the api response object for a pipelineconfig
@@ -141,6 +142,28 @@ type PipelineStatus struct {
 	Schedulable bool `json:"schedulable"`
 }
 
+// ScheduleMaterial describes a material that must be used to trigger a new instance of the pipeline.
+type ScheduleMaterial struct {
+	Name        string `json:"name,omitempty"` // Name is used to build a post query for GoCD version < 18.2.0
+	Fingerprint string `json:"fingerprint"`
+	Revision    string `json:"revision"`
+}
+
+// ScheduleRequestBody describes properties to trigger a new instance of the pipeline.
+type ScheduleRequestBody struct {
+	EnvironmentVariables            []*EnvironmentVariable `json:"environment_variables,omitempty"`
+	Materials                       []*ScheduleMaterial    `json:"materials,omitempty"`
+	UpdateMaterialsBeforeScheduling bool                   `json:"update_materials_before_scheduling"`
+}
+
+// pipelineActionRequest describes pipeline action details
+type pipelineActionRequest struct {
+	Action   string
+	Pipeline string
+	Body     interface{}
+	RawQuery string
+}
+
 // GetStatus returns a list of pipeline instanves describing the pipeline history.
 func (pgs *PipelinesService) GetStatus(ctx context.Context, name string, offset int) (ps *PipelineStatus, resp *APIResponse, err error) {
 	ps = &PipelineStatus{}
@@ -154,25 +177,50 @@ func (pgs *PipelinesService) GetStatus(ctx context.Context, name string, offset 
 
 // Pause allows a pipeline to handle new build events
 func (pgs *PipelinesService) Pause(ctx context.Context, name string) (bool, *APIResponse, error) {
-	return pgs.pipelineAction(ctx, name, "pause")
+	return pgs.pipelineAction(ctx, &pipelineActionRequest{
+		Action:   "pause",
+		Pipeline: name,
+	})
 }
 
 // Unpause allows a pipeline to handle new build events
 func (pgs *PipelinesService) Unpause(ctx context.Context, name string) (bool, *APIResponse, error) {
-	return pgs.pipelineAction(ctx, name, "unpause")
+	return pgs.pipelineAction(ctx, &pipelineActionRequest{
+		Action:   "unpause",
+		Pipeline: name,
+	})
 }
 
 // ReleaseLock frees a pipeline to handle new build events
 func (pgs *PipelinesService) ReleaseLock(ctx context.Context, name string) (bool, *APIResponse, error) {
-	return pgs.pipelineAction(ctx, name, "releaseLock")
+	return pgs.pipelineAction(ctx, &pipelineActionRequest{
+		Action:   "releaseLock",
+		Pipeline: name,
+	})
+}
+
+// Schedule allows to trigger a specific pipeline.
+func (pgs *PipelinesService) Schedule(ctx context.Context, name string, body *ScheduleRequestBody) (bool, *APIResponse, error) {
+
+	request := pipelineActionRequest{
+		Pipeline: name,
+		Action:   "schedule",
+		RawQuery: buildScheduleQuery(body),
+	}
+
+	if body != nil {
+		request.Body = body
+	}
+
+	return pgs.pipelineAction(ctx, &request)
 }
 
 // GetInstance of a pipeline run.
-func (pgs *PipelinesService) GetInstance(ctx context.Context, name string, offset int) (pt *PipelineInstance, resp *APIResponse, err error) {
+func (pgs *PipelinesService) GetInstance(ctx context.Context, name string, counter int) (pt *PipelineInstance, resp *APIResponse, err error) {
 
 	pt = &PipelineInstance{}
 	_, resp, err = pgs.client.getAction(ctx, &APIClientRequest{
-		Path:         pgs.buildPaginatedStub("admin/pipelines/%s/instance", name, offset),
+		Path:         fmt.Sprintf("pipelines/%s/instance/%d", name, counter),
 		ResponseBody: &pt,
 	})
 
@@ -191,20 +239,24 @@ func (pgs *PipelinesService) GetHistory(ctx context.Context, name string, offset
 	return
 }
 
-func (pgs *PipelinesService) pipelineAction(ctx context.Context, name string, action string) (bool, *APIResponse, error) {
+func (pgs *PipelinesService) pipelineAction(ctx context.Context, request *pipelineActionRequest) (bool, *APIResponse, error) {
 
-	apiVersion, err := pgs.client.getAPIVersion(ctx, fmt.Sprintf("pipelines/:pipeline_name/%s", action))
+	apiVersion, err := pgs.client.getAPIVersion(ctx, fmt.Sprintf("pipelines/:pipeline_name/%s", request.Action))
 	if err != nil {
 		return false, nil, err
 	}
 
-	request := &APIClientRequest{
-		Path:       fmt.Sprintf("pipelines/%s/%s", name, action),
-		APIVersion: apiVersion,
+	apiRequest := &APIClientRequest{
+		Path:        fmt.Sprintf("pipelines/%s/%s", request.Pipeline, request.Action),
+		APIVersion:  apiVersion,
+		RequestBody: request.Body,
 	}
-	choosePipelineConfirmHeader(request, apiVersion)
 
-	_, resp, err := pgs.client.postAction(ctx, request)
+	setPostData(apiRequest, request.RawQuery, apiVersion)
+
+	choosePipelineConfirmHeader(apiRequest, apiVersion)
+
+	_, resp, err := pgs.client.postAction(ctx, apiRequest)
 
 	return resp.HTTP.StatusCode == 200, resp, err
 }
@@ -226,4 +278,33 @@ func choosePipelineConfirmHeader(request *APIClientRequest, apiVersion string) {
 		request.ResponseBody = &map[string]interface{}{}
 	}
 
+}
+
+func setPostData(request *APIClientRequest, query string, apiVersion string) {
+	if query != "" && apiVersion == apiV0 {
+		request.Path = fmt.Sprintf("%s?%s", request.Path, query)
+		request.RequestBody = nil
+	}
+}
+
+func buildScheduleQuery(body *ScheduleRequestBody) string {
+	if body == nil {
+		return ""
+	}
+
+	params := url.Values{}
+
+	for _, m := range body.Materials {
+		params.Add(fmt.Sprintf("materials[%s]", m.Name), m.Revision)
+	}
+
+	for _, v := range body.EnvironmentVariables {
+		if v.Secure {
+			params.Add(fmt.Sprintf("secure_variables[%s]", v.Name), v.Value)
+		} else {
+			params.Add(fmt.Sprintf("variables[%s]", v.Name), v.Value)
+		}
+	}
+
+	return params.Encode()
 }

--- a/gocd/pipelinetemplate_test.go
+++ b/gocd/pipelinetemplate_test.go
@@ -58,6 +58,12 @@ func TestPipelineTemplateCreate(t *testing.T) {
 	setup()
 	defer teardown()
 
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+		j, _ := ioutil.ReadFile("test/resources/version.1.json")
+		fmt.Fprint(w, string(j))
+	})
+
 	mux.HandleFunc("/api/admin/templates", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "POST", "Unexpected HTTP method")
 		apiVersion, _ := client.getAPIVersion(context.Background(), "admin/templates")

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -30,6 +30,9 @@ func init() {
 			"/api/pipelines/:pipeline_name/releaseLock": newVersionCollection(
 				newServerAPI("14.3.0", apiV0),
 				newServerAPI("18.2.0", apiV1)),
+			"/api/pipelines/:pipeline_name/schedule": newVersionCollection(
+				newServerAPI("14.3.0", apiV0),
+				newServerAPI("18.2.0", apiV1)),
 			"/api/admin/plugin_info": newVersionCollection(
 				newServerAPI("16.7.0", apiV1),
 				newServerAPI("16.12.0", apiV2),

--- a/gocd/test/request/schedule-pipeline.0.json
+++ b/gocd/test/request/schedule-pipeline.0.json
@@ -1,0 +1,30 @@
+{
+  "environment_variables": [
+    {
+      "name": "USERNAME",
+      "value": "gocd",
+      "secure": false
+    },
+    {
+      "name": "SSH_PASSPHRASE",
+      "value": "some passphrase",
+      "secure": true
+    },
+    {
+      "name": "PASSWORD",
+      "encrypted_value": "YEepp1G0C05SpP0fcp4Jh",
+      "secure": true
+    }
+  ],
+  "materials": [
+    {
+      "fingerprint": "45",
+      "revision": "123"
+    },
+    {
+      "fingerprint": "89",
+      "revision": "67"
+    }
+  ],
+  "update_materials_before_scheduling": false
+}

--- a/gocd/test/resources/version.2.json
+++ b/gocd/test/resources/version.2.json
@@ -1,0 +1,15 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://build.go.cd/go/api/version"
+    },
+    "doc": {
+      "href": "https://api.gocd.org/18.2.0/#version"
+    }
+  },
+  "version": "18.2.0",
+  "build_number": "10194",
+  "git_sha": "34fca8f7682a65ef5fbd6726d51fd52b0c041bc6",
+  "full_version": "18.2.0 (10194-34fca8f7682a65ef5fbd6726d51fd52b0c041bc6)",
+  "commit_url": "https://github.com/gocd/gocd/commit/34fca8f7682a65ef5fbd6726d51fd52b0c041bc6"
+}


### PR DESCRIPTION
Support for https://api.gocd.org/19.5.0/#scheduling-pipelines has been added.

## Description
- Schedule() function has been added to PipelinesService (supports unversionned (>=14.3.0) and v1 (18.2.0) APIs)
- GetInstance function has been switched to `api/pipelines` endpoint from `api/admin/pipelines` since the last one is used in PipelineConfigService and it looks like GetInstance does not work for the newest version of GoCD server.
-  `go generate` diff check has been fixed for the master branch

## Related Issue
https://github.com/beamly/go-gocd/issues/151

## Motivation and Context
https://github.com/beamly/go-gocd/issues/151

## How Has This Been Tested?

I've introduced the new tests:
- TestPipelineServiceSchedule
- TestPipelineServiceScheduleWithBody
- TestPipelineServiceScheduleWithBodyForUnversionnedAPI

and updated this one (since there was the switch to other api endpoint):
- TestPipelineService/Get

Environment:
The tests are passed against all configured combinations of golang (go1.11.13 and go1.13.1) and GoCD servers (v17.10.0 and v19.5.0).

Also I've run tests against go1.12.9 since this is my local dev env.