### PR TITLE
Add support for Environments API v3 (GoCD 19.9.0 and over)

### DIFF
--- a/gocd/environment.go
+++ b/gocd/environment.go
@@ -49,11 +49,16 @@ type PatchStringAction struct {
 
 // List all environments
 func (es *EnvironmentsService) List(ctx context.Context) (e *EnvironmentsResponse, resp *APIResponse, err error) {
+	apiVersion, err := es.client.getAPIVersion(ctx, "admin/environments")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	e = &EnvironmentsResponse{}
 	_, resp, err = es.client.getAction(ctx, &APIClientRequest{
 		Path:         "admin/environments",
 		ResponseBody: e,
-		APIVersion:   apiV2,
+		APIVersion:   apiVersion,
 	})
 
 	return
@@ -61,18 +66,28 @@ func (es *EnvironmentsService) List(ctx context.Context) (e *EnvironmentsRespons
 
 // Delete an environment
 func (es *EnvironmentsService) Delete(ctx context.Context, name string) (string, *APIResponse, error) {
-	return es.client.deleteAction(ctx, "admin/environments/"+name, apiV2)
+	apiVersion, err := es.client.getAPIVersion(ctx, "admin/environments/:environment_name")
+	if err != nil {
+		return "", nil, err
+	}
+
+	return es.client.deleteAction(ctx, "admin/environments/"+name, apiVersion)
 }
 
 // Create an environment
 func (es *EnvironmentsService) Create(ctx context.Context, name string) (e *Environment, resp *APIResponse, err error) {
+	apiVersion, err := es.client.getAPIVersion(ctx, "admin/environments")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	_, resp, err = es.client.postAction(ctx, &APIClientRequest{
 		Path: "admin/environments/",
 		RequestBody: Environment{
 			Name: name,
 		},
 		ResponseBody: &e,
-		APIVersion:   apiV2,
+		APIVersion:   apiVersion,
 	})
 
 	return
@@ -80,11 +95,16 @@ func (es *EnvironmentsService) Create(ctx context.Context, name string) (e *Envi
 
 // Get a single environment by name
 func (es *EnvironmentsService) Get(ctx context.Context, name string) (e *Environment, resp *APIResponse, err error) {
+	apiVersion, err := es.client.getAPIVersion(ctx, "admin/environments/:environment_name")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	e = &Environment{}
 	_, resp, err = es.client.getAction(ctx, &APIClientRequest{
 		Path:         "admin/environments/" + name,
 		ResponseBody: e,
-		APIVersion:   apiV2,
+		APIVersion:   apiVersion,
 	})
 
 	return
@@ -92,12 +112,17 @@ func (es *EnvironmentsService) Get(ctx context.Context, name string) (e *Environ
 
 // Patch an environments configuration by adding or removing pipelines, agents, environment variables
 func (es *EnvironmentsService) Patch(ctx context.Context, name string, patch *EnvironmentPatchRequest) (e *Environment, resp *APIResponse, err error) {
+	apiVersion, err := es.client.getAPIVersion(ctx, "admin/environments/:environment_name")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	e = &Environment{}
 	_, resp, err = es.client.patchAction(ctx, &APIClientRequest{
 		Path:         "admin/environments/" + name,
 		RequestBody:  patch,
 		ResponseBody: e,
-		APIVersion:   apiV2,
+		APIVersion:   apiVersion,
 	})
 
 	return

--- a/gocd/environment_test.go
+++ b/gocd/environment_test.go
@@ -84,10 +84,31 @@ func testEnvironmentIntegration(t *testing.T) {
 
 	assert.NotNil(t, envs)
 
+	// Make sure version-specific expected values are set
+	apiVersion, err := intClient.getAPIVersion(ctx, "admin/environments")
+	assert.NoError(t, err)
+
+	var envDoc, envFind, pipelineDoc, pipelineFind, pipelineSelf string
+
+	switch apiVersion {
+	case apiV3:
+		envDoc = "https://api.go.cd/current/#environment-config"
+		envFind = "http://127.0.0.1:8153/go/api/admin/environments/:name"
+		pipelineDoc = "https://api.go.cd/current/#pipelines"
+		pipelineFind = "/api/admin/pipelines/:pipeline_name"
+		pipelineSelf = "http://127.0.0.1:8153/go/api/pipelines/environment-pipeline/history"
+	case apiV2:
+		envDoc = "https://api.gocd.org/#environment-config"
+		envFind = "http://127.0.0.1:8153/go/api/admin/environments/:environment_name"
+		pipelineDoc = "https://api.gocd.org/#pipeline-config"
+		pipelineFind = "http://127.0.0.1:8153/go/api/admin/pipelines/:pipeline_name"
+		pipelineSelf = "http://127.0.0.1:8153/go/api/admin/pipelines/environment-pipeline"
+	}
+
 	assert.NotNil(t, envs.Links.Get("Self"))
 	assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/environments", envs.Links.Get("Self").URL.String())
 	assert.NotNil(t, envs.Links.Get("Doc"))
-	assert.Equal(t, "https://api.go.cd/current/#environment-config", envs.Links.Get("Doc").URL.String())
+	assert.Equal(t, envDoc, envs.Links.Get("Doc").URL.String())
 
 	assert.NotNil(t, envs.Embedded)
 	assert.NotNil(t, envs.Embedded.Environments)
@@ -96,8 +117,8 @@ func testEnvironmentIntegration(t *testing.T) {
 	env = envs.Embedded.Environments[0]
 	assert.NotNil(t, env.Links)
 	assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/environments/test", env.Links.Get("Self").URL.String())
-	assert.Equal(t, "https://api.go.cd/current/#environment-config", env.Links.Get("Doc").URL.String())
-	assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/environments/:name", env.Links.Get("Find").URL.String())
+	assert.Equal(t, envDoc, env.Links.Get("Doc").URL.String())
+	assert.Equal(t, envFind, env.Links.Get("Find").URL.String())
 
 	assert.Equal(t, "test", env.Name)
 
@@ -106,9 +127,9 @@ func testEnvironmentIntegration(t *testing.T) {
 
 	p = env.Pipelines[0]
 	assert.NotNil(t, p.Links)
-	assert.Equal(t, "http://127.0.0.1:8153/go/api/pipelines/environment-pipeline/history", p.Links.Get("Self").URL.String())
-	assert.Equal(t, "https://api.go.cd/current/#pipelines", p.Links.Get("Doc").URL.String())
-	assert.Equal(t, "/api/admin/pipelines/:pipeline_name", p.Links.Get("Find").URL.String())
+	assert.Equal(t, pipelineSelf, p.Links.Get("Self").URL.String())
+	assert.Equal(t, pipelineDoc, p.Links.Get("Doc").URL.String())
+	assert.Equal(t, pipelineFind, p.Links.Get("Find").URL.String())
 	assert.Equal(t, "environment-pipeline", p.Name)
 
 	assert.NotNil(t, env.EnvironmentVariables)

--- a/gocd/environment_test.go
+++ b/gocd/environment_test.go
@@ -142,9 +142,12 @@ func testEnvironmentIntegration(t *testing.T) {
 }
 
 func testEnvironmentList(t *testing.T) {
+	apiVersion, err := client.getAPIVersion(context.Background(), "admin/environments")
+	assert.NoError(t, err)
+
 	mux.HandleFunc("/api/admin/environments", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
+		assert.Contains(t, r.Header["Accept"], apiVersion)
 
 		j, _ := ioutil.ReadFile("test/resources/environment.0.json")
 		fmt.Fprint(w, string(j))
@@ -209,9 +212,12 @@ func testEnvironmentList(t *testing.T) {
 }
 
 func testEnvironmentDelete(t *testing.T) {
+	apiVersion, err := client.getAPIVersion(context.Background(), "admin/environments/:environment_name")
+	assert.NoError(t, err)
+
 	mux.HandleFunc("/api/admin/environments/my_environment_1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "DELETE", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
+		assert.Contains(t, r.Header["Accept"], apiVersion)
 
 		fmt.Fprint(w, `{
   "message": "Environment 'my_environment_1' was deleted successfully."
@@ -227,9 +233,12 @@ func testEnvironmentDelete(t *testing.T) {
 }
 
 func testEnvironmentGet(t *testing.T) {
+	apiVersion, err := client.getAPIVersion(context.Background(), "admin/environments/:environment_name")
+	assert.NoError(t, err)
+
 	mux.HandleFunc("/api/admin/environments/my_environment", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
+		assert.Contains(t, r.Header["Accept"], apiVersion)
 
 		j, _ := ioutil.ReadFile("test/resources/environment.1.json")
 		fmt.Fprint(w, string(j))
@@ -284,9 +293,12 @@ func testEnvironmentGet(t *testing.T) {
 }
 
 func testEnvironmentPatch(t *testing.T) {
+	apiVersion, err := client.getAPIVersion(context.Background(), "admin/environments/:environment_name")
+	assert.NoError(t, err)
+
 	mux.HandleFunc("/api/admin/environments/my_environment_2", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "PATCH", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
+		assert.Contains(t, r.Header["Accept"], apiVersion)
 
 		j, _ := ioutil.ReadFile("test/resources/environment.2.json")
 		fmt.Fprint(w, string(j))

--- a/gocd/environment_test.go
+++ b/gocd/environment_test.go
@@ -10,8 +10,16 @@ import (
 )
 
 func TestEnvironment(t *testing.T) {
+	t.Run("Integration", testEnvironmentIntegration)
+
 	setup()
 	defer teardown()
+
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
+		j, _ := ioutil.ReadFile("test/resources/version.3.json")
+		fmt.Fprint(w, string(j))
+	})
 
 	t.Run("List", testEnvironmentList)
 	t.Run("Delete", testEnvironmentDelete)
@@ -19,10 +27,103 @@ func TestEnvironment(t *testing.T) {
 	t.Run("Patch", testEnvironmentPatch)
 }
 
+func testEnvironmentIntegration(t *testing.T) {
+	if !runIntegrationTest(t) {
+		t.Skip("Skipping acceptance tests as GOCD_ACC not set to 1")
+	}
+
+	ctx := context.Background()
+
+	env, _, err := intClient.Environments.Create(ctx, "test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	p := &Pipeline{
+		Name: "environment-pipeline",
+		Materials: []Material{{
+			Type: "git",
+			Attributes: MaterialAttributesGit{
+				URL:         "git@github.com:sample_repo/example.git",
+				Destination: "dest",
+				Branch:      "master",
+			},
+		}},
+		Stages: buildUpstreamPipelineStages(),
+	}
+
+	_, _, err = intClient.PipelineConfigs.Create(ctx, "test-group", p)
+	if err != nil {
+		t.Error(err)
+	}
+
+	patch := EnvironmentPatchRequest{
+		Pipelines: &PatchStringAction{
+			Add:    []string{"environment-pipeline"},
+			Remove: []string{},
+		},
+		EnvironmentVariables: &EnvironmentVariablesAction{
+			Add: []*EnvironmentVariable{
+				{
+					Name:  "GO_SERVER_URL",
+					Value: "https://ci.example.com/go",
+				},
+			},
+			Remove: []string{},
+		},
+	}
+	_, _, err = intClient.Environments.Patch(context.Background(), "test", &patch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	envs, _, err := intClient.Environments.List(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.NotNil(t, envs)
+
+	assert.NotNil(t, envs.Links.Get("Self"))
+	assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/environments", envs.Links.Get("Self").URL.String())
+	assert.NotNil(t, envs.Links.Get("Doc"))
+	assert.Equal(t, "https://api.go.cd/current/#environment-config", envs.Links.Get("Doc").URL.String())
+
+	assert.NotNil(t, envs.Embedded)
+	assert.NotNil(t, envs.Embedded.Environments)
+	assert.Len(t, envs.Embedded.Environments, 1)
+
+	env = envs.Embedded.Environments[0]
+	assert.NotNil(t, env.Links)
+	assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/environments/test", env.Links.Get("Self").URL.String())
+	assert.Equal(t, "https://api.go.cd/current/#environment-config", env.Links.Get("Doc").URL.String())
+	assert.Equal(t, "http://127.0.0.1:8153/go/api/admin/environments/:name", env.Links.Get("Find").URL.String())
+
+	assert.Equal(t, "test", env.Name)
+
+	assert.NotNil(t, env.Pipelines)
+	assert.Len(t, env.Pipelines, 1)
+
+	p = env.Pipelines[0]
+	assert.NotNil(t, p.Links)
+	assert.Equal(t, "http://127.0.0.1:8153/go/api/pipelines/environment-pipeline/history", p.Links.Get("Self").URL.String())
+	assert.Equal(t, "https://api.go.cd/current/#pipelines", p.Links.Get("Doc").URL.String())
+	assert.Equal(t, "/api/admin/pipelines/:pipeline_name", p.Links.Get("Find").URL.String())
+	assert.Equal(t, "environment-pipeline", p.Name)
+
+	assert.NotNil(t, env.EnvironmentVariables)
+	assert.Len(t, env.EnvironmentVariables, 1)
+
+	ev1 := env.EnvironmentVariables[0]
+	assert.Equal(t, "GO_SERVER_URL", ev1.Name)
+	assert.False(t, ev1.Secure)
+	assert.Equal(t, "https://ci.example.com/go", ev1.Value)
+}
+
 func testEnvironmentList(t *testing.T) {
 	mux.HandleFunc("/api/admin/environments", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v2+json")
+		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
 
 		j, _ := ioutil.ReadFile("test/resources/environment.0.json")
 		fmt.Fprint(w, string(j))
@@ -89,7 +190,7 @@ func testEnvironmentList(t *testing.T) {
 func testEnvironmentDelete(t *testing.T) {
 	mux.HandleFunc("/api/admin/environments/my_environment_1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "DELETE", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v2+json")
+		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
 
 		fmt.Fprint(w, `{
   "message": "Environment 'my_environment_1' was deleted successfully."
@@ -107,7 +208,7 @@ func testEnvironmentDelete(t *testing.T) {
 func testEnvironmentGet(t *testing.T) {
 	mux.HandleFunc("/api/admin/environments/my_environment", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "GET", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v2+json")
+		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
 
 		j, _ := ioutil.ReadFile("test/resources/environment.1.json")
 		fmt.Fprint(w, string(j))
@@ -164,7 +265,7 @@ func testEnvironmentGet(t *testing.T) {
 func testEnvironmentPatch(t *testing.T) {
 	mux.HandleFunc("/api/admin/environments/my_environment_2", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Method, "PATCH", "Unexpected HTTP method")
-		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v2+json")
+		assert.Contains(t, r.Header["Accept"], "application/vnd.go.cd.v3+json")
 
 		j, _ := ioutil.ReadFile("test/resources/environment.2.json")
 		fmt.Fprint(w, string(j))

--- a/gocd/resource_server_version.go
+++ b/gocd/resource_server_version.go
@@ -59,6 +59,12 @@ func init() {
 			"/api/admin/security/roles/:role_name": newVersionCollection(
 				newServerAPI("17.5.0", apiV1),
 				newServerAPI("19.2.0", apiV2)),
+			"/api/admin/environments": newVersionCollection(
+				newServerAPI("16.7.0", apiV2),
+				newServerAPI("19.9.0", apiV3)),
+			"/api/admin/environments/:environment_name": newVersionCollection(
+				newServerAPI("16.7.0", apiV2),
+				newServerAPI("19.9.0", apiV3)),
 		},
 	}
 }

--- a/gocd/test/resources/version.3.json
+++ b/gocd/test/resources/version.3.json
@@ -1,0 +1,15 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:8153/go/api/version"
+    },
+    "doc" : {
+      "href" : "https://api.gocd.org/19.9.0/#version"
+    }
+  },
+  "version" : "19.9.0",
+  "build_number" : "10194",
+  "git_sha" : "34fca8f7682a65ef5fbd6726d51fd52b0c041bc6",
+  "full_version" : "19.9.0 (10194-34fca8f7682a65ef5fbd6726d51fd52b0c041bc6)",
+  "commit_url" : "https://github.com/gocd/gocd/commit/34fca8f7682a65ef5fbd6726d51fd52b0c041bc6"
+}


### PR DESCRIPTION
## Description
Add support for Environments API v3 (GoCD 19.9.0 and over) along with a new integration test for Environments API.

## How Has This Been Tested?
Updates to existing tests and a new integration tests.
